### PR TITLE
[FE] fix: yml 레포지토리를 받아오고 의존성 설치하는 로직 추가

### DIFF
--- a/.github/workflows/front-release-deploy.yml
+++ b/.github/workflows/front-release-deploy.yml
@@ -17,15 +17,15 @@ jobs:
         uses: npm install
 
       - name: ✅ 유닛 테스트
-        working-directory: frontEnd
+        working-directory: ./frontEnd
         run: npm test
 
       - name: 📦 프로젝트 빌드
-        working-directory: frontEnd
+        working-directory: ./frontEnd
         run: npm run build
 
       - name: ⬆️ Object Storage 업로드
-        working-directory: frontEnd
+        working-directory: ./frontEnd
         env:
           AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
           AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'

--- a/.github/workflows/front-release-deploy.yml
+++ b/.github/workflows/front-release-deploy.yml
@@ -10,6 +10,12 @@ jobs:
       matrix:
         node-version: [18.16.0]
     steps:
+      - name: 체크아웃
+        uses: actions/checkout@v3
+
+      - name: 의존성 설치
+        uses: npm install
+
       - name: ✅ 유닛 테스트
         working-directory: frontEnd
         run: npm test


### PR DESCRIPTION
## PR 설명
yml 레포지토리를 받아오고 의존성 설치하는 로직 추가

## ✅ 완료한 기능 명세
- [x] github 레포지토리 다운로드 (checkout) 사용
- [x] 의존성 설치 로직 작성
- [x] working-directory 재설정

## 고민과 해결과정
working directory를 계속해서 찾지 못하는 오류가 있었는데, 이는 actions 도커에 github 코드를 주지 않았기 때문이다...
checkout 하는 부분을 추가해주었고, 의존성 설치도 하지않았었는데, 그 부분을 해주었다. 