### PR TITLE
[FE] feat: 프론트엔드 WebRTC 구현 

### DIFF
--- a/frontEnd/.eslintrc.cjs
+++ b/frontEnd/.eslintrc.cjs
@@ -23,5 +23,7 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'import/extensions': ['off'],
+    'react-hooks/exhaustive-deps': 'off',
   },
 };

--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.18.0"
+        "react-router-dom": "^6.18.0",
+        "socket.io-client": "^4.7.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -19,6 +20,7 @@
         "@types/node": "^20.8.10",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.7",
+        "@types/socket.io-client": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.0.3",
@@ -1999,6 +2001,11 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
@@ -2438,6 +2445,16 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
       "dev": true
+    },
+    "node_modules/@types/socket.io-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-3.0.0.tgz",
+      "integrity": "sha512-s+IPvFoEIjKA3RdJz/Z2dGR4gLgysKi8owcnrVwNjgvc01Lk68LJDDsG2GRqegFITcxmvCMYM7bhMpwEMlHmDg==",
+      "deprecated": "This is a stub types definition. socket.io-client provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "socket.io-client": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.2",
@@ -3846,7 +3863,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4229,6 +4245,46 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+      "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -8925,8 +8981,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -10235,6 +10290,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+      "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11357,6 +11438,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.18.0"
+    "react-router-dom": "^6.18.0",
+    "socket.io-client": "^4.7.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",
@@ -22,6 +23,7 @@
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.7",
+    "@types/socket.io-client": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.0.3",

--- a/frontEnd/src/constants/socketEvents.ts
+++ b/frontEnd/src/constants/socketEvents.ts
@@ -1,0 +1,12 @@
+export const SOCKET_RECEIVE_EVENT = {
+  ALL_USERS: 'all_users',
+  OFFER: 'getOffer',
+  ANSWER: 'getAnswer',
+  CANDIDATE: 'getCandidate',
+  USER_EXIT: 'user_exit',
+};
+
+export const SOCKET_EMIT_EVENT = {
+  OFFER: 'offer',
+  ANSWER: 'answer',
+};

--- a/frontEnd/src/constants/socketEvents.ts
+++ b/frontEnd/src/constants/socketEvents.ts
@@ -9,4 +9,5 @@ export const SOCKET_RECEIVE_EVENT = {
 export const SOCKET_EMIT_EVENT = {
   OFFER: 'offer',
   ANSWER: 'answer',
+  JOIN_ROOM: 'join_room',
 };

--- a/frontEnd/src/constants/urls.ts
+++ b/frontEnd/src/constants/urls.ts
@@ -1,1 +1,1 @@
-export const SOCKET_URL = `http://localhost:3000`;
+export const SOCKET_URL = `ws://localhost:4000`;

--- a/frontEnd/src/constants/urls.ts
+++ b/frontEnd/src/constants/urls.ts
@@ -1,0 +1,1 @@
+export const SOCKET_URL = `http://localhost:3000`;

--- a/frontEnd/src/constants/urls.ts
+++ b/frontEnd/src/constants/urls.ts
@@ -1,1 +1,2 @@
 export const SOCKET_URL = `ws://localhost:4000`;
+export const API_URL = `http://localhost:4000`;

--- a/frontEnd/src/main.tsx
+++ b/frontEnd/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Home from '@pages/Home.tsx';
@@ -15,8 +14,4 @@ const router = createBrowserRouter([
     element: <Room />,
   },
 ]);
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
-);
+ReactDOM.createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />);

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,3 +1,34 @@
+import { RTCConnectionList, createSocket } from '@/services/Socket';
+import { useEffect, useRef } from 'react';
+
+function StreamVideo({ stream }: { stream: MediaStream }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    (videoRef.current as HTMLVideoElement).srcObject = stream;
+  }, []);
+
+  return <video ref={videoRef}></video>;
+}
+
 export default function Room() {
-  return <div>Room</div>;
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    navigator.mediaDevices
+      .getUserMedia({
+        video: true,
+      })
+      .then((video) => {
+        (videoRef.current as HTMLVideoElement).srcObject = video;
+        createSocket(video);
+      });
+  }, []);
+
+  return (
+    <div>
+      <video ref={videoRef} muted autoPlay></video>
+      {Object.entries(RTCConnectionList).map(([key, value]) => value.stream && <StreamVideo key={key} stream={value.stream} />)}
+    </div>
+  );
 }

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -16,7 +16,7 @@ function StreamVideo({ stream }: { stream: MediaStream }) {
 
 export default function Room() {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [stream, setStream] = useState<StreamObject[]>([]);
+  const [streamList, setStreamList] = useState<StreamObject[]>([]);
   const { roomId } = useParams();
 
   useEffect(() => {
@@ -27,7 +27,7 @@ export default function Room() {
       .then((video) => {
         (videoRef.current as HTMLVideoElement).srcObject = video;
         streamModel.subscribe(() => {
-          setStream(() => streamModel.getStream());
+          setStreamList(() => streamModel.getStream());
         });
         const socket = createSocket(video);
         socket.connect();
@@ -40,8 +40,8 @@ export default function Room() {
   return (
     <div>
       <video ref={videoRef} muted autoPlay />
-      {stream.map((item) => {
-        return <StreamVideo key={item.id} stream={item.stream} />;
+      {streamList.map(({ id, stream }) => {
+        return <StreamVideo key={id} stream={stream} />;
       })}
     </div>
   );

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createSocket } from '@/services/Socket';
 import { StreamObject, streamModel } from '@/stores/StreamModel';
+import { SOCKET_EMIT_EVENT } from '@/constants/socketEvents';
 
 function StreamVideo({ stream }: { stream: MediaStream }) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -27,7 +28,7 @@ export default function Room() {
         });
         const socket = createSocket(video);
         socket.connect();
-        socket.emit('join_room', {
+        socket.emit(SOCKET_EMIT_EVENT.JOIN_ROOM, {
           room: '1234',
         });
       });

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { createSocket } from '@/services/Socket';
 import { StreamObject, streamModel } from '@/stores/StreamModel';
 import { SOCKET_EMIT_EVENT } from '@/constants/socketEvents';
@@ -16,6 +17,8 @@ function StreamVideo({ stream }: { stream: MediaStream }) {
 export default function Room() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [stream, setStream] = useState<StreamObject[]>([]);
+  const { roomId } = useParams();
+
   useEffect(() => {
     navigator.mediaDevices
       .getUserMedia({
@@ -29,7 +32,7 @@ export default function Room() {
         const socket = createSocket(video);
         socket.connect();
         socket.emit(SOCKET_EMIT_EVENT.JOIN_ROOM, {
-          room: '1234',
+          room: roomId,
         });
       });
   }, []);

--- a/frontEnd/src/services/RTC.ts
+++ b/frontEnd/src/services/RTC.ts
@@ -1,31 +1,29 @@
 import { Socket } from 'socket.io-client/debug';
+import { streamModel } from '@/stores/StreamModel';
 
-export interface ExtendedRTCPeerConnection extends RTCPeerConnection {
-  stream?: MediaStream;
-}
-
-export const createPeerConnection = (socketId: string, socket: Socket, localStream: MediaStream) => {
-  const RTCConnection = new RTCPeerConnection();
+const createPeerConnection = (socketId: string, socket: Socket, localStream: MediaStream) => {
+  const RTCConnection = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:stun.1.google.com:19302' }],
+  });
   if (localStream) {
     localStream.getTracks().forEach((track) => {
       RTCConnection.addTrack(track, localStream);
     });
   }
-  const result: ExtendedRTCPeerConnection = {
-    ...RTCConnection,
-  };
-
-  result.addEventListener('icecandidate', (e) => {
-    socket.emit('candidate', {
-      candidate: e.candidate,
-      candidateSendId: socket.id,
-      candidateReceiveId: socketId,
-    });
+  RTCConnection.addEventListener('icecandidate', (e) => {
+    if (e.candidate != null)
+      socket.emit('candidate', {
+        candidate: e.candidate,
+        candidateSendId: socket.id,
+        candidateReceiveId: socketId,
+      });
   });
 
-  result.addEventListener('track', (e) => {
-    result.stream = e.streams[0];
+  RTCConnection.addEventListener('track', (e) => {
+    streamModel.addStream({ id: socketId, stream: e.streams[0] });
   });
 
-  return result;
+  return RTCConnection;
 };
+
+export default createPeerConnection;

--- a/frontEnd/src/services/RTC.ts
+++ b/frontEnd/src/services/RTC.ts
@@ -1,0 +1,31 @@
+import { Socket } from 'socket.io-client/debug';
+
+export interface ExtendedRTCPeerConnection extends RTCPeerConnection {
+  stream?: MediaStream;
+}
+
+export const createPeerConnection = (socketId: string, socket: Socket, localStream: MediaStream) => {
+  const RTCConnection = new RTCPeerConnection();
+  if (localStream) {
+    localStream.getTracks().forEach((track) => {
+      RTCConnection.addTrack(track, localStream);
+    });
+  }
+  const result: ExtendedRTCPeerConnection = {
+    ...RTCConnection,
+  };
+
+  result.addEventListener('icecandidate', (e) => {
+    socket.emit('candidate', {
+      candidate: e.candidate,
+      candidateSendId: socket.id,
+      candidateReceiveId: socketId,
+    });
+  });
+
+  result.addEventListener('track', (e) => {
+    result.stream = e.streams[0];
+  });
+
+  return result;
+};

--- a/frontEnd/src/services/Socket.ts
+++ b/frontEnd/src/services/Socket.ts
@@ -1,0 +1,60 @@
+import { SOCKET_URL } from '@/constants/urls';
+import { io } from 'socket.io-client/debug';
+import { ExtendedRTCPeerConnection, createPeerConnection } from './RTC';
+import { SOCKET_EMIT_EVENT, SOCKET_RECEIVE_EVENT } from '@/constants/socketEvents';
+
+export const RTCConnectionList: Record<string, ExtendedRTCPeerConnection> = {};
+
+export const createSocket = (localStream: MediaStream) => {
+  const socket = io(SOCKET_URL);
+
+  socket.on(SOCKET_RECEIVE_EVENT.ALL_USERS, async (data: { users: Array<{ id: string }> }) => {
+    data.users.map((user) => (RTCConnectionList[user.id] = createPeerConnection(user.id, socket, localStream)));
+
+    Object.entries(RTCConnectionList).forEach(async ([key, value]) => {
+      const offer = await value.createOffer({
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: true,
+      });
+
+      await value.setLocalDescription(new RTCSessionDescription(offer));
+      socket.emit(SOCKET_EMIT_EVENT.OFFER, {
+        sdp: offer,
+        offerSendId: socket.id,
+        offerReceiveId: key,
+      });
+    });
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.OFFER, async (data: { sdp: RTCSessionDescription; offerSendId: string }) => {
+    RTCConnectionList[data.offerSendId] = createPeerConnection(data.offerSendId, socket, localStream);
+
+    await RTCConnectionList[data.offerSendId].setRemoteDescription(new RTCSessionDescription(data.sdp));
+    const answer = await RTCConnectionList[data.offerSendId].createAnswer({
+      offerToReceiveAudio: true,
+      offerToReceiveVideo: true,
+    });
+
+    await RTCConnectionList[data.offerSendId].setLocalDescription(new RTCSessionDescription(answer));
+    socket.emit(SOCKET_EMIT_EVENT.ANSWER, {
+      sdp: answer,
+      answerSendId: socket.id,
+      answerReceiveId: data.offerSendId,
+    });
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.ANSWER, (data: { sdp: RTCSessionDescription; answerSendId: string }) => {
+    RTCConnectionList[data.answerSendId].setRemoteDescription(new RTCSessionDescription(data.sdp));
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.CANDIDATE, (data: { candidate: RTCIceCandidateInit; candidateSendId: string }) => {
+    RTCConnectionList[data.candidateSendId].addIceCandidate(new RTCIceCandidate(data.candidate));
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.USER_EXIT, (data: { id: string }) => {
+    RTCConnectionList[data.id].close();
+    delete RTCConnectionList[data.id];
+  });
+
+  return socket;
+};

--- a/frontEnd/src/stores/StreamModel.ts
+++ b/frontEnd/src/stores/StreamModel.ts
@@ -1,0 +1,31 @@
+import Observer from '@/utils/Observer';
+
+export interface StreamObject {
+  id: string;
+  stream: MediaStream;
+}
+
+export class StreamModel extends Observer {
+  streams: StreamObject[];
+
+  constructor() {
+    super();
+    this.streams = [];
+  }
+
+  getStream() {
+    return [...this.streams];
+  }
+
+  addStream(stream: StreamObject) {
+    this.streams.push(stream);
+    this.notify();
+  }
+
+  removeStream(id: string) {
+    this.streams = this.streams.filter((stream) => stream.id !== id);
+    this.notify();
+  }
+}
+
+export const streamModel = new StreamModel();

--- a/frontEnd/src/utils/Observer.ts
+++ b/frontEnd/src/utils/Observer.ts
@@ -1,0 +1,15 @@
+export default class Observer {
+  observers: Set<() => void>;
+
+  constructor() {
+    this.observers = new Set();
+  }
+
+  subscribe(func: () => void) {
+    this.observers.add(func);
+  }
+
+  notify() {
+    this.observers.forEach((func) => func());
+  }
+}


### PR DESCRIPTION
## PR 설명
프론트엔드 WebRTC 구현 
WebRTC를 mesh방식의 P2P로 구현

## ✅ 완료한 기능 명세
- [x] observer패턴을 활용한 의존성 문제 해결
- [x] streamModel 구현
- [x] Socket.io를 사용한 소켓 서버 연결
- [x] WebRTC API를 사용한 WebRTC 로직 구현 

## 📸 스크린샷

## 고민과 해결과정

WebRTC 로직

### 1:1 의 경우 이벤트 흐름정리

**`사용자 A`, `사용자 B`** 가 webRTC로 통신하는 상황

1. **`사용자 A`**, 방에 입장
2. **`사용자 B`**, 방에 입장시 welcome이벤트 발생, 서버로 전달
3.  **`사용자 A`** , welcome 이벤트수신
4. **`사용자 A`**, offer생성 + setLocalDescription을 통해 자신의 offer세팅
5. **`사용자 A`**, offer 이벤트발생, 서버로 전달
6. **`사용자 B`** , offer 이벤트 수신, offer를 setRemoteDescription으로 세팅, answer객체 생성 후 setLocalDescription을 통해 answer를 세팅
7. **`사용자 B`**, answer 이벤트 발생, 서버로 전달
8. **`사용자 A`**, answer 이벤트 수신,setRemoteDescription으로 세팅
9. localDescripton과 remoteDescription이 모두 설정되어 ICECandidates를 수집하기 시작함 ⇒ **`icecandidate 이벤트가 발생`**
10. rtc connection객체에 등록된 icecandidate 이벤트핸들러로 등록된 함수에서 ice 이벤트 발생, 서버로 전송, data.candiate데이터 전송
11. 서버에서 방의 모든 사용자에게 data.candidate를 브로드캐스팅
12. 사용자 각각은 data.candidate를 addIceCandidate함수로 추가함
13. rtc connection객체에 등록된 addstream이벤트핸들러로 등록된 함수에서 받아온 data stream을 보여주는 형태로 peer간 스트림 교환이 일어남


### 1:n의 경우

위의 경우에서 사용하는 RTCPeerConnection객체를 socket id를 키로 갖는 객체로 관리
해당 객체에 대해 sdp를 설정하여 연결 구현

![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/886455ee-47cb-4b5a-9759-89d63f71c4bb)


### 렌더링 문제

RTCPeerConnection객체가 비동기적으로 이벤트에 의해 업데이트되어, 화면에 제대로 그려주지 못하는 문제가 발생
해당 문제를 해결하기 위해 track 이벤트와 close 이벤트가 발생하면 객체를 변화시키고, 다시 렌더링 시키는 로직을 Observer패턴을 활용해 구현

Room에서 setState함수를 이벤트 발생시 콜백으로 사용하여 리렌더링을 할 수 있도록 함 

### setState의 불변성...

이렇게 했는데도 불구하고 제대로 렌더링이 되지 않는 문제가 발생했음

이는 StreamModel의 getStream이 항상 같은 참조값을 내보내기때문이었음
```typescript
export class StreamModel extends Observer {
  streams: StreamObject[];
  ...
  getStream() {
    return this.streams;
  }
...
```
스프레드 연산자를 통해 불변 객체를 내보내주어 해결함
```typescript
  getStream() {
    return [...this.streams];
  }
```