### PR TITLE
[FE] fix: eslint tsconfigRootDir 추가

### DIFF
--- a/frontEnd/.eslintrc.cjs
+++ b/frontEnd/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
     project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {


### PR DESCRIPTION
## PR 설명
- eslint에서 tsconfig 파일을 찾지 못하는 문제를 해결하기 위해 .eslintrc.cjs parserOptions에 tsconfigRootDir: __dirname 추가

## ✅ 완료한 기능 명세
- [x] .eslintrc.cjs parserOptions에 tsconfigRootDir: __dirname 추가

## 📸 스크린샷
```diff
  parserOptions: {
    (...)
+   tsconfigRootDir: __dirname
  }
```