### PR TITLE
[FE] fix: WebRTC에서 remote description이 등록되기 전에 ice candidate가 제대로 교환되지 않던 문제 해결

### DIFF
--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -20,7 +20,6 @@
         "@types/node": "^20.8.10",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.7",
-        "@types/socket.io-client": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.0.3",
@@ -2445,16 +2444,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
       "dev": true
-    },
-    "node_modules/@types/socket.io-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-3.0.0.tgz",
-      "integrity": "sha512-s+IPvFoEIjKA3RdJz/Z2dGR4gLgysKi8owcnrVwNjgvc01Lk68LJDDsG2GRqegFITcxmvCMYM7bhMpwEMlHmDg==",
-      "deprecated": "This is a stub types definition. socket.io-client provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "socket.io-client": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.2",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -23,7 +23,6 @@
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.7",
-    "@types/socket.io-client": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.0.3",

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -6,8 +6,10 @@ import { SOCKET_EMIT_EVENT } from '@/constants/socketEvents';
 
 function StreamVideo({ stream }: { stream: MediaStream }) {
   const videoRef = useRef<HTMLVideoElement>(null);
+
   useEffect(() => {
     if (!videoRef.current) return;
+
     videoRef.current.srcObject = stream;
   }, []);
 
@@ -25,11 +27,14 @@ export default function Room() {
         video: true,
       })
       .then((video) => {
-        (videoRef.current as HTMLVideoElement).srcObject = video;
+        if (videoRef.current) videoRef.current.srcObject = video;
+
         streamModel.subscribe(() => {
           setStreamList(() => streamModel.getStream());
         });
+
         const socket = createSocket(video);
+
         socket.connect();
         socket.emit(SOCKET_EMIT_EVENT.JOIN_ROOM, {
           room: roomId,
@@ -40,9 +45,9 @@ export default function Room() {
   return (
     <div>
       <video ref={videoRef} muted autoPlay />
-      {streamList.map(({ id, stream }) => {
-        return <StreamVideo key={id} stream={stream} />;
-      })}
+      {streamList.map(({ id, stream }) => (
+        <StreamVideo key={id} stream={stream} />
+      ))}
     </div>
   );
 }

--- a/frontEnd/src/services/RTC.ts
+++ b/frontEnd/src/services/RTC.ts
@@ -1,15 +1,17 @@
 import { Socket } from 'socket.io-client/debug';
 import { streamModel } from '@/stores/StreamModel';
 
-const createPeerConnection = (socketId: string, socket: Socket, localStream: MediaStream) => {
+const createPeerConnection = (socketId: string, socket: Socket, localStream: MediaStream): RTCPeerConnection => {
   const RTCConnection = new RTCPeerConnection({
     iceServers: [{ urls: 'stun:stun.1.google.com:19302' }],
   });
+
   if (localStream) {
     localStream.getTracks().forEach((track) => {
       RTCConnection.addTrack(track, localStream);
     });
   }
+
   RTCConnection.addEventListener('icecandidate', (e) => {
     if (e.candidate != null)
       socket.emit('candidate', {

--- a/frontEnd/src/services/Socket.ts
+++ b/frontEnd/src/services/Socket.ts
@@ -54,8 +54,7 @@ export const createSocket = (localStream: MediaStream): Socket => {
   });
 
   socket.on(SOCKET_RECEIVE_EVENT.CANDIDATE, (data: { candidate: RTCIceCandidateInit; candidateSendId: string }) => {
-    if (RTCConnectionList[data.candidateSendId].remoteDescription)
-      RTCConnectionList[data.candidateSendId].addIceCandidate(new RTCIceCandidate(data.candidate));
+    RTCConnectionList[data.candidateSendId].addIceCandidate(new RTCIceCandidate(data.candidate));
   });
 
   socket.on(SOCKET_RECEIVE_EVENT.USER_EXIT, (data: { id: string }) => {

--- a/frontEnd/src/services/Socket.ts
+++ b/frontEnd/src/services/Socket.ts
@@ -1,4 +1,4 @@
-import { io } from 'socket.io-client/debug';
+import { Socket, io } from 'socket.io-client/debug';
 import { SOCKET_URL } from '@/constants/urls';
 import createPeerConnection from './RTC';
 import { SOCKET_EMIT_EVENT, SOCKET_RECEIVE_EVENT } from '@/constants/socketEvents';
@@ -6,7 +6,7 @@ import { streamModel } from '@/stores/StreamModel';
 
 export const RTCConnectionList: Record<string, RTCPeerConnection> = {};
 
-export const createSocket = (localStream: MediaStream) => {
+export const createSocket = (localStream: MediaStream): Socket => {
   const socket = io(SOCKET_URL);
 
   socket.on(SOCKET_RECEIVE_EVENT.ALL_USERS, async (data: { users: Array<{ id: string }> }) => {
@@ -21,6 +21,7 @@ export const createSocket = (localStream: MediaStream) => {
       });
 
       await value.setLocalDescription(new RTCSessionDescription(offer));
+
       socket.emit(SOCKET_EMIT_EVENT.OFFER, {
         sdp: offer,
         offerSendId: socket.id,
@@ -31,13 +32,16 @@ export const createSocket = (localStream: MediaStream) => {
 
   socket.on(SOCKET_RECEIVE_EVENT.OFFER, async (data: { sdp: RTCSessionDescription; offerSendId: string }) => {
     RTCConnectionList[data.offerSendId] = createPeerConnection(data.offerSendId, socket, localStream);
+
     await RTCConnectionList[data.offerSendId].setRemoteDescription(new RTCSessionDescription(data.sdp));
+
     const answer = await RTCConnectionList[data.offerSendId].createAnswer({
       offerToReceiveAudio: true,
       offerToReceiveVideo: true,
     });
 
     await RTCConnectionList[data.offerSendId].setLocalDescription(new RTCSessionDescription(answer));
+
     socket.emit(SOCKET_EMIT_EVENT.ANSWER, {
       sdp: answer,
       answerSendId: socket.id,


### PR DESCRIPTION
## PR 설명
- WebRTC에서 remote description이 등록되기 전에 ice candidate가 제대로 교환되지 않던 문제 해결

## ✅ 완료한 기능 명세
- ice candidate 수신 이벤트 핸들러에서 remote description의 존재 여부를 확인하는 if문 제거