### PR TITLE
[FE] config: ncp object storage에서 s3, cloudfront를 사용한 배포로 변경

### DIFF
--- a/.github/workflows/front-ci.yml
+++ b/.github/workflows/front-ci.yml
@@ -1,0 +1,26 @@
+name: frontEnd CI
+on:
+  pull_request:
+    branches: [FE/release, dev, main]
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        node-version: [18.16.0]
+    steps:
+      - name: ✅ 코드 체크아웃
+        uses: actions/checkout@v3
+
+      - name: ⬇️ 의존성 설치
+        working-directory: ./frontEnd
+        run: npm install
+
+      - name: ✅ 유닛 테스트
+        working-directory: ./frontEnd
+        run: npm test
+
+      - name: 📦 프로젝트 빌드
+        working-directory: ./frontEnd
+        run: npm run build

--- a/.github/workflows/front-release-deploy.yml
+++ b/.github/workflows/front-release-deploy.yml
@@ -25,11 +25,15 @@ jobs:
         working-directory: ./frontEnd
         run: npm run build
 
-      - name: ⬆️ Object Storage 업로드
+      - name: ⬆️ S3업로드
         working-directory: ./frontEnd
         env:
           AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
           AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
           AWS_DEFAULT_REGION: '${{secrets.AWS_DEFAULT_REGION}}'
         run: |
-          aws --endpoint-url=https://kr.object.ncloudstorage.com s3 cp --recursive dist s3://algoitni
+          aws s3 sync ./dist s3://algoitni-deploy
+
+      - name: 🔄️ Cloudfront edge 로케이션에 대한 캐시 무효화
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{secrets.AWS_CLOUD_FRONT_ID}} --paths "/*"

--- a/.github/workflows/front-release-deploy.yml
+++ b/.github/workflows/front-release-deploy.yml
@@ -1,7 +1,7 @@
-name: frontEnd test deploy
+name: frontEnd CI/CD
 on:
-  pull_request:
-    branches: FE/release
+  push:
+    branches: [FE/release, main]
 jobs:
   build-test-deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## PR 설명
프론트엔드 배포방식을 object storage를 사용한 방식에서 s3와 cloudFront를 사용한 방식으로 변경했다.

## ✅ 완료한 기능 명세
- [x] ncp object storage삭제
- [x] s3, cloudfront로 배포방식 변경
- [x] 프론트엔드 배포 전략 변경

## 📸 스크린샷

## 고민과 해결과정

### Object Storage에서 S3로 이전한 이유

Object Storage는 커스텀 도메인이 붙지 않기 때문이다...
또한 기존에 aws cli명령어를 통해서 Object Storage에 접근하고 있었기 때문에 가장 비슷한 S3버킷을 사용한 방식으로 바꾸어주었다.

![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/f9b000c9-4487-43a3-8a8f-d1879e73b654)


### OAI적용

S3 버킷의 모든 데이터를 퍼블릭으로 설정하거나, 웹사이트 호스팅을 하는 형태가 아니라 CloudFront 배포를 통해서만 리소스에 접근 할 수 있게 했다.


### 배포 전략 수정

main, FE/release에 push되는 경우에만 deploy되게 했고, 다른 경우에는 CI만 하도록 yml을 두개 작성했다.
dev에 머지 될때마다 새롭게 배포되는것보다는 CI만 시키는 것이 합리적이라는 판단이다.