### PR TITLE
[FE] refactor: WebRTC 코드 useRoom으로 변경 및 .env 설정

### DIFF
--- a/frontEnd/.gitignore
+++ b/frontEnd/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.production
+.env.development

--- a/frontEnd/src/hooks/useRoom.ts
+++ b/frontEnd/src/hooks/useRoom.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { io } from 'socket.io-client/debug';
 import { SOCKET_EMIT_EVENT, SOCKET_RECEIVE_EVENT } from '@/constants/socketEvents';
-import { SOCKET_URL } from '@/constants/urls';
 
 const useRoom = (roomId: string) => {
   const [streamList, setStreamList] = useState<{ id: string; stream: MediaStream }[]>([]);
@@ -10,7 +9,7 @@ const useRoom = (roomId: string) => {
 
   const RTCConnections: Record<string, RTCPeerConnection> = {};
 
-  const socket = io(SOCKET_URL);
+  const socket = io(`${import.meta.env.VITE_SOCKET_URL}`);
 
   useEffect(() => {
     navigator.mediaDevices

--- a/frontEnd/src/hooks/useRoom.ts
+++ b/frontEnd/src/hooks/useRoom.ts
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from 'react';
+import { io } from 'socket.io-client/debug';
+import { SOCKET_EMIT_EVENT, SOCKET_RECEIVE_EVENT } from '@/constants/socketEvents';
+import { SOCKET_URL } from '@/constants/urls';
+
+const useRoom = (roomId: string) => {
+  const [RTCConnections, setRTCConnections] = useState<Record<string, RTCPeerConnection>>({});
+  const [streamList, setStreamList] = useState<{ id: string; stream: MediaStream }[]>([]);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const localStream = useRef<MediaStream | null>(null);
+
+  const tempRTCConnections: Record<string, RTCPeerConnection> = {};
+
+  const socket = io(SOCKET_URL);
+
+  useEffect(() => {
+    navigator.mediaDevices
+      .getUserMedia({
+        video: true,
+      })
+      .then((video) => {
+        if (videoRef.current) videoRef.current.srcObject = video;
+
+        localStream.current = video;
+
+        socket.connect();
+        socket.emit(SOCKET_EMIT_EVENT.JOIN_ROOM, {
+          room: roomId,
+        });
+      });
+  }, []);
+
+  const createPeerConnection = (socketId: string): RTCPeerConnection => {
+    const RTCConnection = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.1.google.com:19302' }],
+    });
+
+    if (localStream.current) {
+      localStream.current.getTracks().forEach((track) => {
+        RTCConnection.addTrack(track, localStream.current as MediaStream);
+      });
+    }
+
+    RTCConnection.addEventListener('icecandidate', (e) => {
+      if (e.candidate != null)
+        socket.emit('candidate', {
+          candidate: e.candidate,
+          candidateSendId: socket.id,
+          candidateReceiveId: socketId,
+        });
+    });
+
+    RTCConnection.addEventListener('track', (e) => {
+      setStreamList((prev) => [...prev, { id: socketId, stream: e.streams[0] }]);
+    });
+
+    return RTCConnection;
+  };
+
+  socket.on(SOCKET_RECEIVE_EVENT.ALL_USERS, async (data: { users: Array<{ id: string }> }) => {
+    data.users.forEach((user) => {
+      tempRTCConnections[user.id] = createPeerConnection(user.id);
+    });
+
+    Object.entries(tempRTCConnections).forEach(async ([key, value]) => {
+      const offer = await value.createOffer({
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: true,
+      });
+
+      await value.setLocalDescription(new RTCSessionDescription(offer));
+
+      socket.emit(SOCKET_EMIT_EVENT.OFFER, {
+        sdp: offer,
+        offerSendId: socket.id,
+        offerReceiveId: key,
+      });
+    });
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.OFFER, async (data: { sdp: RTCSessionDescription; offerSendId: string }) => {
+    tempRTCConnections[data.offerSendId] = createPeerConnection(data.offerSendId);
+
+    await tempRTCConnections[data.offerSendId].setRemoteDescription(new RTCSessionDescription(data.sdp));
+
+    const answer = await tempRTCConnections[data.offerSendId].createAnswer({
+      offerToReceiveAudio: true,
+      offerToReceiveVideo: true,
+    });
+
+    await tempRTCConnections[data.offerSendId].setLocalDescription(new RTCSessionDescription(answer));
+
+    socket.emit(SOCKET_EMIT_EVENT.ANSWER, {
+      sdp: answer,
+      answerSendId: socket.id,
+      answerReceiveId: data.offerSendId,
+    });
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.ANSWER, (data: { sdp: RTCSessionDescription; answerSendId: string }) => {
+    tempRTCConnections[data.answerSendId].setRemoteDescription(new RTCSessionDescription(data.sdp));
+
+    setRTCConnections(tempRTCConnections);
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.CANDIDATE, (data: { candidate: RTCIceCandidateInit; candidateSendId: string }) => {
+    tempRTCConnections[data.candidateSendId].addIceCandidate(new RTCIceCandidate(data.candidate));
+
+    setRTCConnections(tempRTCConnections);
+  });
+
+  socket.on(SOCKET_RECEIVE_EVENT.USER_EXIT, (data: { id: string }) => {
+    tempRTCConnections[data.id].close();
+    delete tempRTCConnections[data.id];
+
+    setStreamList((prev) => prev.filter((stream) => stream.id !== data.id));
+    setRTCConnections(tempRTCConnections);
+  });
+
+  return { videoRef, socket, RTCConnections, streamList };
+};
+
+export default useRoom;

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { createSocket } from '@/services/Socket';
-import { StreamObject, streamModel } from '@/stores/StreamModel';
-import { SOCKET_EMIT_EVENT } from '@/constants/socketEvents';
+import useRoom from '@/hooks/useRoom';
 
 function StreamVideo({ stream }: { stream: MediaStream }) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -17,30 +15,8 @@ function StreamVideo({ stream }: { stream: MediaStream }) {
 }
 
 export default function Room() {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const [streamList, setStreamList] = useState<StreamObject[]>([]);
   const { roomId } = useParams();
-
-  useEffect(() => {
-    navigator.mediaDevices
-      .getUserMedia({
-        video: true,
-      })
-      .then((video) => {
-        if (videoRef.current) videoRef.current.srcObject = video;
-
-        streamModel.subscribe(() => {
-          setStreamList(() => streamModel.getStream());
-        });
-
-        const socket = createSocket(video);
-
-        socket.connect();
-        socket.emit(SOCKET_EMIT_EVENT.JOIN_ROOM, {
-          room: roomId,
-        });
-      });
-  }, []);
+  const { videoRef, streamList } = useRoom(roomId as string);
 
   return (
     <div>


### PR DESCRIPTION
## PR 설명
- WebRTC 코드 useRoom으로 변경 및 .env 설정

## ✅ 완료한 기능 명세
- [x] WebRTC 의존성 문제 해결
- [x] useRoom 커스텀 훅 생성
- [x] .env 적용

## 📸 스크린샷
<img width="903" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/9b01190f-0e6b-44de-8a66-44865be42836">

## 고민과 해결과정
- 사용자들의 스트림 정보를 관리하는 과정에서 새로운 사용자가 들어오는 등의 경우 해당 스트림을 업데이트 하면서 재렌더링을 해야했음
  - 이를 해결하기 위해 useRoom 훅으로 변환하고 해당 훅 안에서 streamList를 관리할 수 있도록 함
  - 해당 state를 반환하여 컴포넌트에서 사용할 수 있도록 했으며 state가 변화함에 따라 재렌더링이 일어날 수 있도록 구성
  ```ts
  const useRoom = (roomId: string) => {
    const [streamList, setStreamList] = useState<{ id: string; stream: MediaStream }[]>([]);
  ```