### PR TITLE
[FE] feat: CRDT (yjs 라이브러리) 적용

### DIFF
--- a/frontEnd/.eslintrc.cjs
+++ b/frontEnd/.eslintrc.cjs
@@ -28,5 +28,6 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'off',
     'no-param-reassign': 'off',
     'react/no-array-index-key': 'off',
+    'react/no-danger': 'off',
   },
 };

--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
         "socket.io-client": "^4.7.2",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "yjs": "^13.6.8"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -6266,6 +6267,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.1.tgz",
@@ -8412,6 +8422,25 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.87",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.87.tgz",
+      "integrity": "sha512-TbB63XJixvNToW2IHWAFsCJj9tVnajmwjE14p69i51Rx8byOQd2IP4ourE8v4d7vhyO++nVm1sQk3ePslfbucg==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lilconfig": {
@@ -11536,6 +11565,22 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yn": {

--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -8,6 +8,8 @@
       "name": "front-end",
       "version": "0.0.0",
       "dependencies": {
+        "dompurify": "^3.0.6",
+        "highlight.js": "^11.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
@@ -17,6 +19,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^14.0.0",
+        "@types/dompurify": "^3.0.5",
         "@types/jest": "^29.5.7",
         "@types/node": "^20.8.10",
         "@types/react": "^18.2.37",
@@ -2302,6 +2305,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
@@ -2457,6 +2469,12 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.4.tgz",
       "integrity": "sha512-95Sfz4nvMAb0Nl9DTxN3j64adfwfbBPEYq14VN7zT5J5O2M9V6iZMIIQU1U+pJyl9agHYHNCqhCXgyEtIRRa5A==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.6.tgz",
+      "integrity": "sha512-HYtNooPvUY9WAVRBr4u+4Qa9fYD1ze2IUlAD3HoA6oehn1taGwBx3Oa52U4mTslTS+GAExKpaFu39Y5xUEwfjg==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -4213,6 +4231,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5658,6 +5681,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
     "socket.io-client": "^4.7.2",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "yjs": "^13.6.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -11,6 +11,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "dompurify": "^3.0.6",
+    "highlight.js": "^11.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
@@ -20,6 +22,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",
+    "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.7",
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.37",

--- a/frontEnd/src/components/Editor.tsx
+++ b/frontEnd/src/components/Editor.tsx
@@ -1,8 +1,29 @@
+import { useEffect, useState, useRef } from 'react';
+import dompurify from 'dompurify';
+import hljs from 'highlight.js';
+
 export default function Editor({ value, onChange }: { value: string; onChange: React.ChangeEventHandler<HTMLTextAreaElement> }) {
+  const sanitizer = dompurify.sanitize;
+  const [highlightedHTML, setHighlightedCode] = useState('');
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    setHighlightedCode(hljs.highlight(value, { language: 'python' }).value.replace(/" "/g, '&nbsp; '));
+  }, [value]);
+
+  const handleScroll = (event: React.UIEvent<HTMLPreElement | HTMLTextAreaElement>) => {
+    if (!preRef.current || !textareaRef.current) return;
+
+    if (event.target === textareaRef.current) preRef.current.scrollLeft = textareaRef.current.scrollLeft;
+    else textareaRef.current.scrollLeft = preRef.current.scrollLeft;
+  };
+
   return (
     <div className="w-full h-full rounded-lg bg-mainColor font-Pretendard">
       <h1 className="p-2 text-white border-b border-white h-[5%] text-xs">Solution.py</h1>
-      <div className="flex flex-col overflow-auto h-[65%] custom-scroll">
+      <div className="flex flex-col h-[65%] overflow-y-auto custom-scroll">
         <div className="flex flex-grow">
           <div className="w-10 py-2 pr-2 overflow-hidden border-r border-white">
             {value.split('\n').map((_, index) => (
@@ -11,11 +32,23 @@ export default function Editor({ value, onChange }: { value: string; onChange: R
               </div>
             ))}
           </div>
-          <textarea
-            value={value}
-            onChange={onChange}
-            className="w-full p-2 pb-0 overflow-hidden overflow-x-scroll leading-7 text-white resize-none custom-scroll whitespace-nowrap focus:outline-none bg-mainColor"
-          />
+          <div className="relative w-full h-full">
+            <textarea
+              onScroll={handleScroll}
+              ref={textareaRef}
+              value={value}
+              onChange={onChange}
+              autoComplete="false"
+              spellCheck="false"
+              className="z-10 absolute w-full tracking-[3px] h-full p-2 pb-0 leading-7 overflow-hidden overflow-x-scroll text-transparent bg-transparent resize-none caret-white custom-scroll whitespace-nowrap focus:outline-none bg-mainColor"
+            />
+            <pre onScroll={handleScroll} className="absolute top-0 left-0 z-0 w-full h-full p-2 overflow-hidden" ref={preRef}>
+              <code
+                className="tracking-[3px] text-white font-Pretendard leading-7 w-full h-full text-ellipsis"
+                dangerouslySetInnerHTML={{ __html: sanitizer(highlightedHTML) }}
+              />
+            </pre>
+          </div>
         </div>
       </div>
       <div className="flex flex-col h-[30%]">

--- a/frontEnd/src/components/Editor.tsx
+++ b/frontEnd/src/components/Editor.tsx
@@ -20,12 +20,6 @@ export default function Editor({ dataChannels }: { dataChannels: Array<{ id: str
     setPlainCode(ytext.current.toString());
   };
 
-  useEffect(() => {
-    dataChannels.forEach(({ dataChannel }) => {
-      dataChannel.onmessage = handleMessage;
-    });
-  }, [dataChannels]);
-
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     ytext.current.delete(0, ytext.current.length);
     ytext.current.insert(0, event.target.value);
@@ -37,16 +31,22 @@ export default function Editor({ dataChannels }: { dataChannels: Array<{ id: str
     setPlainCode(event.target.value);
   };
 
-  useEffect(() => {
-    setHighlightedCode(hljs.highlight(plainCode, { language: 'python' }).value.replace(/" "/g, '&nbsp; '));
-  }, [plainCode]);
-
   const handleScroll = (event: React.UIEvent<HTMLPreElement | HTMLTextAreaElement>) => {
     if (!preRef.current || !textareaRef.current) return;
 
     if (event.target === textareaRef.current) preRef.current.scrollLeft = textareaRef.current.scrollLeft;
     else textareaRef.current.scrollLeft = preRef.current.scrollLeft;
   };
+
+  useEffect(() => {
+    dataChannels.forEach(({ dataChannel }) => {
+      dataChannel.onmessage = handleMessage;
+    });
+  }, [dataChannels]);
+
+  useEffect(() => {
+    setHighlightedCode(hljs.highlight(plainCode, { language: 'python' }).value.replace(/" "/g, '&nbsp; '));
+  }, [plainCode]);
 
   return (
     <div className="w-full h-full rounded-lg bg-mainColor font-Pretendard">

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import useRoom from '@/hooks/useRoom';
 import Editor from '@/components/Editor';
@@ -19,26 +19,6 @@ export default function Room() {
   const { roomId } = useParams();
   const { videoRef, streamList, dataChannels } = useRoom(roomId as string);
 
-  const [text, setText] = useState<string>('');
-
-  const handleMessage = (event: MessageEvent) => {
-    setText(event.data);
-  };
-
-  useEffect(() => {
-    dataChannels.forEach(({ dataChannel }) => {
-      dataChannel.onmessage = handleMessage;
-    });
-  }, [dataChannels]);
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setText(event.target.value);
-
-    dataChannels.forEach(({ dataChannel }) => {
-      if (dataChannel.readyState === 'open') dataChannel.send(event.target.value);
-    });
-  };
-
   return (
     <div>
       <video ref={videoRef} muted autoPlay />
@@ -46,7 +26,7 @@ export default function Room() {
         <StreamVideo key={id} stream={stream} />
       ))}
       <div className="w-[700px] h-[600px]">
-        <Editor onChange={handleChange} value={text} />
+        <Editor dataChannels={dataChannels} />
       </div>
     </div>
   );

--- a/frontEnd/src/styles/editor.css
+++ b/frontEnd/src/styles/editor.css
@@ -1,0 +1,125 @@
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+
+.hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/frontEnd/src/styles/index.css
+++ b/frontEnd/src/styles/index.css
@@ -1,8 +1,10 @@
 @import './font.css';
+@import './editor.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
 html,
 body {
   width: 100%;
@@ -23,5 +25,5 @@ body {
 }
 
 .custom-scroll::-webkit-scrollbar-track {
-  @apply bg-mainColor
+  @apply bg-mainColor;
 }


### PR DESCRIPTION
## PR 설명
- CRDT (yjs 라이브러리) 적용
- close #54 

## ✅ 완료한 기능 명세
- [x] yjs를 이용한 CRDT 알고리즘 적용
- [x] RTCPeerConnection을 이용한 텍스트 송수신
- [x] 코드 하이라이팅 (Python 기준) 

## 📸 스크린샷
<img width="578" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/b5717941-efc1-42c5-994f-b6599544cf0f">

## 고민과 해결과정
- 에디터에서는 `textarea` 태그를 사용중이기 때문에 부분적인 하이라이팅이 불가능
  - `highlight.js` 모듈을 설치하고 `<pre><code></code></pre>`를 이용해 라이라이트 된 코드를 보여줄 수 있도록 구성
  - 단, 입력은 여전히 textarea를 사용하고 사용자에게 보이는 부분이 `<pre>` 부분이 되어야 함
  - 이를 위해 `position: absolute`를 이용해 textarea와 pre가 겹치도록 한 뒤, textarea의 z-index를 pre보다 높게 설정하여 textarea가 클릭되도록 구성
  - 둘의 자간, 행간 너비를 동일하게 하여 완전히 겹쳐질 수 있도록 구성
  - 결과적으로 실제 텍스트는 textarea에 있으며, 사용자에게 보이는 부분은 pre를 이용한 부분이 될 수 있도록 함
  - `<code>`안의 내용을 `dangerouslySetInnerHTML`를 사용하여 설정하기 때문에 XSS에 대한 대비가 필요했음
  - 이를 위해 `dompurify`를 추가하여 텍스트를 검증할 수 있도록 구성
- 또한, textarea와 pre의 스크롤바를 동기화 시켜야 했음
  - 두 요소에 `onscroll`이벤트를 설정하여 같은 비율로 스크롤 될 수 있도록 구성