### PR TITLE
[BE]: feature 코드 실행 타임아웃 설정

### DIFF
--- a/.github/workflows/back-api-cd.yml
+++ b/.github/workflows/back-api-cd.yml
@@ -18,23 +18,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name : 🔐 env 설정
-        working-directory: ./backEnd/api
-        run: |
-          echo "WEB_HOOK_URL=${{secrets.WEB_HOOK_URL}}" >> .env
-          echo "PORT=${{secrets.PORT}}" >> .env
-          echo "DB_HOST=${{secrets.DB_HOST}}" >> .env
-          echo "DB_PORT=${{secrets.DB_PORT}}" >> .env
-          echo "DB_USERNAME=${{secrets.DB_USERNAME}}" >> .env
-          echo "DB_PASSWORD=${{secrets.DB_PASSWORD}}" >> .env
-          echo "DB_DATABASE=${{secrets.DB_DATABASE}}" >> .env
-          echo "SYNCHRONIZED=${{secrets.SYNCHRONIZED}}" >> .env
-          echo "NODE_ENV=production" >> .env
-          echo "RUNNING_SERVER=${{secrets.RUNNING_SERVER_URL}}" >> .env
-          echo "REDIS_HOST=${{secrets.REDIS_HOST}}" >> .env
-          echo "REDIS_PORT=${{secrets.REDIS_PORT}}" >> .env
-          echo "REDIS_PASSWORD=${{secrets.REDIS_PASSWORD}}" >> .env
-
       - name: ⬇️ 의존성 설치
         working-directory: ./backEnd/api
         run: npm install
@@ -63,4 +46,25 @@ jobs:
           password: ${{secrets.API_PASSWORD}}
           port: ${{secrets.API_PORT}}
           script: |
+            cd /root
+            echo "WEB_HOOK_URL=${{secrets.WEB_HOOK_URL}}" >> .env
+            echo "PORT=${{secrets.PORT}}" >> .env
+            echo "DB_HOST=${{secrets.DB_HOST}}" >> .env
+            echo "DB_PORT=${{secrets.DB_PORT}}" >> .env
+            echo "DB_USERNAME=${{secrets.DB_USERNAME}}" >> .env
+            echo "DB_PASSWORD=${{secrets.DB_PASSWORD}}" >> .env
+            echo "DB_DATABASE=${{secrets.DB_DATABASE}}" >> .env
+            echo "SYNCHRONIZED=${{secrets.SYNCHRONIZED}}" >> .env
+            echo "NODE_ENV=production" >> .env
+            echo "RUNNING_SERVER=${{secrets.RUNNING_SERVER_URL}}" >> .env
+            echo "REDIS_HOST=${{secrets.REDIS_HOST}}" >> .env
+            echo "REDIS_PORT=${{secrets.REDIS_PORT}}" >> .env
+            echo "REDIS_PASSWORD=${{secrets.REDIS_PASSWORD}}" >> .env
+            echo "CLIENT_ID_GITHUB=${{secrets.CLIENT_ID_GITHUB}}" >> .env
+            echo "CLIENT_SECRET_GITHUB=${{secrets.CLIENT_SECRET_GITHUB}}" >> .env
+            echo "JWT_ACCESS_SECRET=${{secrets.JWT_ACCESS_SECRET}}" >> .env
+            echo "JWT_ACCESS_EXPIRE=${{secrets.JWT_ACCESS_EXPIRE}}" >> .env
+            echo "JWT_REFRESH_SECRET=${{secrets.JWT_REFRESH_SECRET}}" >> .env
+            echo "JWT_REFRESH_EXPIRE=${{secrets.JWT_REFRESH_EXPIRE}}" >> .env
+        
             bash deploy.sh >> /dev/deploy.log 2>&1

--- a/backEnd/api/Dockerfile
+++ b/backEnd/api/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20.3.1-alpine3.18
-WORKDIR /home/appq
+WORKDIR /home/app
 
 COPY . .
 RUN npm i -g pm2

--- a/backEnd/api/src/common/exception/exception.filter.ts
+++ b/backEnd/api/src/common/exception/exception.filter.ts
@@ -16,11 +16,15 @@ export class ErrorFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
     const status =
       exception instanceof HttpException ? exception.getStatus() : 500;
-    if (!(exception instanceof HttpException)) this.logger.error(exception);
+    const message =
+      exception instanceof HttpException
+        ? exception.message
+        : 'Internal Serval Error';
+    this.logger.error(exception.message, exception);
     response.status(status).json({
       path: request.url,
       statusCode: status,
-      message: exception.message,
+      message,
       timestamp: new Date().toISOString(),
     });
   }

--- a/backEnd/api/src/common/exception/exception.filter.ts
+++ b/backEnd/api/src/common/exception/exception.filter.ts
@@ -20,9 +20,11 @@ export class ErrorFilter implements ExceptionFilter {
       exception instanceof HttpException
         ? exception.message
         : 'Internal Serval Error';
-    this.logger.error(exception.message, exception);
+    this.logger.error(
+      `path : ${request.url} \n${exception.message}`,
+      exception,
+    );
     response.status(status).json({
-      path: request.url,
       statusCode: status,
       message,
       timestamp: new Date().toISOString(),

--- a/backEnd/api/src/redis/redis.service.ts
+++ b/backEnd/api/src/redis/redis.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { ResponseCodeBlockDto } from '../run/dto/response-codeblock.dto';
 
 @Injectable()
 export class RedisService {
@@ -13,16 +14,20 @@ export class RedisService {
     return new Promise((resolve) => setTimeout(resolve, delay));
   };
 
-  async getCompletedJob(jobID): Promise<string | string[]> {
+  async getCompletedJob(jobID): Promise<ResponseCodeBlockDto> {
     this.runningRequest++;
     // this.logger.debug(this.runningRequest)
     this.logger.log(`try to get result to redis completedJob:${jobID}`);
-    const maxTrial = 100;
+    const maxTrial = 1000;
     const getData = async () =>
-      await this.cacheManager.get<string | string[]>(`completedJob:${jobID}`);
+      await this.cacheManager.get<ResponseCodeBlockDto>(
+        `completedJob:${jobID}`,
+      );
+
     let result;
     const interval = 50 * (Math.floor(this.runningRequest / 10) + 1);
     this.statistic_delay_time.push(interval);
+
     for (let i = 0; i < maxTrial; i++) {
       await this.delay(interval);
       result = await getData();

--- a/backEnd/api/src/run/run.controller.ts
+++ b/backEnd/api/src/run/run.controller.ts
@@ -25,12 +25,8 @@ export class RunController {
       throw new VulnerableException();
     }
 
-    const result = await this.runService.requestRunningApi(codeBlock);
-    const responseCodeBlockDto = new ResponseCodeBlockDto(
-      200,
-      result.result,
-      'Running Python Code Success',
-    );
+    const responseCodeBlockDto =
+      await this.runService.requestRunningApi(codeBlock);
     return responseCodeBlockDto;
   }
 

--- a/backEnd/api/src/run/run.controller.ts
+++ b/backEnd/api/src/run/run.controller.ts
@@ -3,7 +3,6 @@ import { RunService } from './run.service';
 import { RequestCodeblockDto } from './dto/request-codeblock.dto';
 import { returnCode } from '../common/returnCode';
 import { VulnerableException } from '../common/exception/exception';
-import { ResponseCodeBlockDto } from './dto/response-codeblock.dto';
 import { MqService } from '../mq/mq.service';
 import { RedisService } from '../redis/redis.service';
 
@@ -40,13 +39,9 @@ export class RunController {
       throw new VulnerableException();
     }
 
-    const result = await this.runService.requestRunningMQ(codeBlock);
+    const responseCodeBlockDto =
+      await this.runService.requestRunningMQ(codeBlock);
 
-    const responseCodeBlockDto = new ResponseCodeBlockDto(
-      200,
-      result,
-      'Running Python Code Success',
-    );
     return responseCodeBlockDto;
   }
 

--- a/backEnd/api/src/run/run.service.ts
+++ b/backEnd/api/src/run/run.service.ts
@@ -90,7 +90,9 @@ export class RunService {
     }
   }
 
-  async requestRunningMQ(codeBlock: RequestCodeblockDto) {
+  async requestRunningMQ(
+    codeBlock: RequestCodeblockDto,
+  ): Promise<ResponseCodeBlockDto> {
     const job = await this.mqService.addMessage(codeBlock);
     this.logger.log(`added message queue job#${job.id}`);
 

--- a/backEnd/running/package-lock.json
+++ b/backEnd/running/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.2.8",
         "@nestjs/platform-socket.io": "^10.2.8",
+        "@nestjs/schedule": "^4.0.0",
         "@nestjs/typeorm": "^10.0.0",
         "@nestjs/websockets": "^10.2.8",
         "@slack/client": "^5.0.2",
@@ -2081,6 +2082,32 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.0.0.tgz",
+      "integrity": "sha512-zz4h54m/F/1qyQKvMJCRphmuwGqJltDAkFxUXCVqJBXEs5kbPt93Pza3heCQOcMH22MZNhGlc9DmDMLXVHmgVQ==",
+      "dependencies": {
+        "cron": "3.1.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
+    "node_modules/@nestjs/schedule/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.0.3.tgz",
@@ -2753,6 +2780,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.4.tgz",
+      "integrity": "sha512-H9OXxv4EzJwE75aTPKpiGXJq+y4LFxjpsdgKwSmr503P5DkWc3AG7VAFYrFNVvqemT5DfgZJV9itYhqBHSGujA=="
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
@@ -4706,6 +4738,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.3.tgz",
+      "integrity": "sha512-KVxeKTKYj2eNzN4ElnT6nRSbjbfhyxR92O/Jdp6SH3pc05CDJws59jBrZWEMQlxevCiE6QUTrXy+Im3vC3oD3A==",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",

--- a/backEnd/running/package.json
+++ b/backEnd/running/package.json
@@ -30,6 +30,7 @@
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.2.8",
     "@nestjs/platform-socket.io": "^10.2.8",
+    "@nestjs/schedule": "^4.0.0",
     "@nestjs/typeorm": "^10.0.0",
     "@nestjs/websockets": "^10.2.8",
     "@slack/client": "^5.0.2",

--- a/backEnd/running/src/codes/codes.service.ts
+++ b/backEnd/running/src/codes/codes.service.ts
@@ -24,10 +24,7 @@ export class CodesService {
     }
   }
 
-  async testCode(
-    code: string,
-    isHttp: boolean = true,
-  ): Promise<ResponseCodeDto | string> {
+  async testCode(code: string): Promise<ResponseCodeDto | string> {
     this.logger.debug('function[testCode] Called');
 
     const filePath = this.getFilePath();
@@ -35,7 +32,6 @@ export class CodesService {
     try {
       fs.writeFileSync(filePath, code);
       const { stdout, stderr } = await this.runCommand(filePath, this.timeOut);
-      console.log(stdout, stderr);
       if (stderr) {
         const errorMessage = this.getErrorMessage(stderr);
         throw new RunningException(errorMessage);
@@ -45,13 +41,11 @@ export class CodesService {
     } catch (error) {
       this.logger.error(error.message);
       const errorMessage = this.getErrorMessage(error.message);
-      if (isHttp) {
-        if (errorMessage === this.unKnownMessage) {
-          throw new InternalServerErrorException();
-        }
-        throw new RunningException(errorMessage);
-      } // Https 요청일 경우
-      else return errorMessage;
+
+      if (errorMessage === this.unKnownMessage) {
+        throw new InternalServerErrorException();
+      }
+      throw new RunningException(errorMessage);
     } finally {
       fs.unlinkSync(filePath);
     }

--- a/backEnd/running/src/common/decorator/timeout.decorator.ts
+++ b/backEnd/running/src/common/decorator/timeout.decorator.ts
@@ -1,0 +1,32 @@
+export function timeout(ms: number) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalMethod = descriptor.value;
+    let timer: NodeJS.Timeout;
+
+    descriptor.value = async function (...args: any[]) {
+      const timeoutPromise = new Promise((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Timeout: ${ms / 1000} seconds exceeded`));
+        }, ms);
+      });
+
+      try {
+        const result = await Promise.race([
+          originalMethod.apply(this, args),
+          timeoutPromise,
+        ]);
+        return result;
+      } catch (error) {
+        throw error;
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+
+    return descriptor;
+  };
+}

--- a/backEnd/running/src/common/exception/exception.filter.ts
+++ b/backEnd/running/src/common/exception/exception.filter.ts
@@ -3,22 +3,31 @@ import {
   Catch,
   ArgumentsHost,
   HttpException,
+  Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 
 @Catch(Error)
 export class ErrorFilter implements ExceptionFilter {
+  private readonly logger = new Logger('Error Filter');
+
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
     const status =
       exception instanceof HttpException ? exception.getStatus() : 500;
-
+    const message =
+      exception instanceof HttpException
+        ? exception.message
+        : 'Internal Serval Error';
+    this.logger.error(
+      `path : ${request.url} \n${exception.message}`,
+      exception,
+    );
     response.status(status).json({
-      path: request.url,
       statusCode: status,
-      message: exception.message,
+      message,
       timestamp: new Date().toISOString(),
     });
   }

--- a/backEnd/running/src/common/exception/exception.ts
+++ b/backEnd/running/src/common/exception/exception.ts
@@ -14,11 +14,8 @@ export class DBException extends Error {
   }
 }
 
-export class RunningException extends Error {
-  status: number;
-
+export class RunningException extends HttpException {
   constructor(message: string = 'RunningException') {
-    super(message);
-    this.status = HttpStatus.BAD_REQUEST;
+    super(message, HttpStatus.BAD_REQUEST);
   }
 }

--- a/backEnd/running/src/common/interceptor/timeout.interceptor.ts
+++ b/backEnd/running/src/common/interceptor/timeout.interceptor.ts
@@ -3,9 +3,10 @@ import {
   NestInterceptor,
   ExecutionContext,
   CallHandler,
+  RequestTimeoutException,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { Observable, throwError, timeout } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
 import { Request } from 'express';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
@@ -18,11 +19,20 @@ export class TimeoutInterceptor implements NestInterceptor {
     const startTime = Date.now();
 
     const request = context.switchToHttp().getRequest();
+    const timeoutValue = this.configService.get<number>('TIMEOUT') | 5000;
 
     return next.handle().pipe(
+      timeout(timeoutValue),
+      catchError((error) => {
+        if (error.name === 'TimeoutError') {
+          return throwError(() => new RequestTimeoutException());
+        } else {
+          return throwError(() => error);
+        }
+      }),
       tap(() => {
         const elapsedTime = Date.now() - startTime;
-        if (elapsedTime > 0) {
+        if (this.configService.get<string>('NODE_ENV') !== 'dev') {
           this.timeOutNotification(elapsedTime, request);
         }
       }),

--- a/backEnd/running/src/mq/dto/response-codeblock.dto.ts
+++ b/backEnd/running/src/mq/dto/response-codeblock.dto.ts
@@ -1,0 +1,9 @@
+export class ResponseCodeBlockDto {
+  statusCode: number;
+  result: string | string[];
+  message: string;
+  timestamp: string;
+  constructor() {
+    this.timestamp = new Date().toISOString();
+  }
+}

--- a/backEnd/running/src/mq/mq.consumer.ts
+++ b/backEnd/running/src/mq/mq.consumer.ts
@@ -1,12 +1,17 @@
 import { Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
 import { RedisService } from '../redis/redis.service';
-import { Logger } from '@nestjs/common';
+import { HttpStatus, Logger } from '@nestjs/common';
 import { CodesService } from '../codes/codes.service';
 import { ResponseCodeDto } from '../codes/dto/response-code.dto ';
+import { ResponseCodeBlockDto } from './dto/response-codeblock.dto';
 @Processor('runningRequest')
 export class MqConsumer {
   private logger = new Logger(MqConsumer.name);
+  private errorMessage = {
+    400: 'Failed to Run Code',
+    201: 'Running Python Code Success',
+  };
   constructor(
     private redisService: RedisService,
     private codesService: CodesService,
@@ -14,16 +19,29 @@ export class MqConsumer {
   @Process('task')
   async getMessageQueue(job: Job) {
     this.logger.debug(`getMessageQueue ${job.id}, ${job.data}`);
-    const result: ResponseCodeDto | string = await this.codesService.testCode(
-      job.data,
-      false,
-    );
-    this.logger.debug(JSON.stringify(result));
+    let result: ResponseCodeDto | string;
+    const responseCodeBlockDTO = new ResponseCodeBlockDto();
+    try {
+      result = await this.codesService.testCode(job.data);
+      const output: string | string[] =
+        typeof result === 'string' ? result : result.output;
+      this.logger.debug(JSON.stringify(result));
 
-    const output: string[] =
-      typeof result === 'string' ? [result] : result.output;
-
-    this.redisService.addCompletedJob(job.id, output);
-    this.logger.log(`${job.id} complete`);
+      responseCodeBlockDTO.statusCode = HttpStatus.CREATED;
+      responseCodeBlockDTO.result = output;
+      responseCodeBlockDTO.message = this.errorMessage[HttpStatus.CREATED];
+    } catch (e) {
+      console.log(e);
+      responseCodeBlockDTO.statusCode = e.status;
+      if (e.status === HttpStatus.INTERNAL_SERVER_ERROR) {
+        responseCodeBlockDTO.message = e.message;
+      } else {
+        responseCodeBlockDTO.result = e.message;
+        responseCodeBlockDTO.message = this.errorMessage[e.status];
+      }
+    } finally {
+      this.logger.log(`${job.id} complete`);
+      return this.redisService.addCompletedJob(job.id, responseCodeBlockDTO);
+    }
   }
 }

--- a/backEnd/running/src/redis/redis.service.ts
+++ b/backEnd/running/src/redis/redis.service.ts
@@ -1,12 +1,13 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { ResponseCodeBlockDto } from '../mq/dto/response-codeblock.dto';
 
 @Injectable()
 export class RedisService {
   private logger = new Logger(RedisService.name);
   constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
-  async addCompletedJob(jobID: string | number, data: string[]) {
+  async addCompletedJob(jobID: string | number, data: ResponseCodeBlockDto) {
     this.logger.log(`add result to redis completedJob:${jobID}`);
     this.cacheManager.set(`completedJob:${jobID}`, data);
   }


### PR DESCRIPTION
## PR 설명
issue #36 
코드 실행 기능 중 실행에 5초이상 걸리는 코드는 중지하는 기능 구현

## ✅ 완료한 기능 명세
- [x] timeout interceptor 수정
- [x] 코드 실행 5초 타임아웃 설정 
- [x] 코드 실행 요청에 대한 응답 형식 통일

## 📸 스크린샷

## 고민과 해결과정
 - timeout interceptor 수정
기존은 timeout 시 http 요청 주기 종료되지 않고 슬랙 알림만 보내짐
dev 환경에서는 슬랙 알림이 보내지지 않고, 타임아웃시 http 수명주기를 종료하게 Timeout Exception을 throw함

- 코드 실행 5초 타임아웃 설정 
파이썬 코드는 자식 프로세스를 생성해서 실행하게 됨.
이때 promise resolve, reject, setTimeout을 이용해서 5초이내에 원래 자식프로세스 실행이 끝나지 않으면 자식프로세스에 `SIGINT` 신호를 보내 종료시킴

- 코드 실행 요청에 대한 응답 형식 통일
코드 실행 요청 api를 구현 방식에 따라 v1, v2로 구성하였는데
실행 방식에 따라서 응답 형식이 다른 문제가 있었음.
api서버와 running 서버에 동일한 DTO를 추가해주어 응답형식을 두 버전이 동일하게 추가해주었음.

