### PR TITLE
[FE] fix: 로그인에서 발생하는 이슈 해결

### DIFF
--- a/frontEnd/src/components/room/EditorSection.tsx
+++ b/frontEnd/src/components/room/EditorSection.tsx
@@ -1,8 +1,10 @@
 import Editor from './editor/Editor';
 
 export default function EditorSection({
+  defaultCode,
   dataChannels,
 }: {
+  defaultCode: string | null;
   dataChannels: {
     id: string;
     dataChannel: RTCDataChannel;
@@ -11,7 +13,7 @@ export default function EditorSection({
   return (
     <div className="basis-3/5">
       <div className="w-full h-full">
-        <Editor dataChannels={dataChannels} />
+        <Editor defaultCode={defaultCode} dataChannels={dataChannels} />
       </div>
     </div>
   );

--- a/frontEnd/src/components/room/editor/Editor.tsx
+++ b/frontEnd/src/components/room/editor/Editor.tsx
@@ -93,7 +93,7 @@ export default function Editor({ dataChannels }: { dataChannels: Array<{ id: str
       </div>
       <div className="flex items-center justify-between row-span-1 gap-2 p-[1vh]">
         <div className="h-full">
-          <LoadButton setPlainCode={setPlainCode} />
+          <LoadButton plainCode={plainCode} setPlainCode={setPlainCode} />
         </div>
         <div className="flex h-full gap-2">
           <SaveButton plainCode={plainCode} />

--- a/frontEnd/src/components/room/editor/Editor.tsx
+++ b/frontEnd/src/components/room/editor/Editor.tsx
@@ -8,8 +8,14 @@ import OutputArea from './OutputArea';
 import { EDITOR_TAB_SIZE } from '@/constants/env';
 import LoadButton from './LoadButton';
 
-export default function Editor({ dataChannels }: { dataChannels: Array<{ id: string; dataChannel: RTCDataChannel }> }) {
-  const [plainCode, setPlainCode] = useState<string>('');
+export default function Editor({
+  defaultCode,
+  dataChannels,
+}: {
+  defaultCode: string | null;
+  dataChannels: Array<{ id: string; dataChannel: RTCDataChannel }>;
+}) {
+  const [plainCode, setPlainCode] = useState<string>(defaultCode || '');
   // TODO: 코드 실행 요청 후 결과 setState 추가
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [execResult] = useState<string>('');
@@ -17,6 +23,10 @@ export default function Editor({ dataChannels }: { dataChannels: Array<{ id: str
 
   const ydoc = useRef(new Y.Doc());
   const ytext = useRef(ydoc.current.getText('sharedText'));
+
+  useEffect(() => {
+    localStorage.removeItem('code');
+  }, []);
 
   const handleMessage = (event: MessageEvent) => {
     Y.applyUpdate(ydoc.current, new Uint8Array(event.data));

--- a/frontEnd/src/components/room/editor/LoadButton.tsx
+++ b/frontEnd/src/components/room/editor/LoadButton.tsx
@@ -16,9 +16,15 @@ function LoadButtonElement({ children, onClick }: { children: React.ReactNode; o
     </button>
   );
 }
-export default function LoadButton({ setPlainCode }: { setPlainCode: (value: React.SetStateAction<string>) => void }) {
+export default function LoadButton({
+  plainCode,
+  setPlainCode,
+}: {
+  plainCode: string;
+  setPlainCode: (value: React.SetStateAction<string>) => void;
+}) {
   const { show, hide } = useModal(CodeListModal);
-  const { show: showLoginModal, hide: hideLoginModal } = useModal(LoginModal);
+  const { show: showLoginModal } = useModal(LoginModal);
 
   const handleLoadLocalCodeFile = () => {
     uploadLocalFile((result) => setPlainCode(result));
@@ -29,8 +35,8 @@ export default function LoadButton({ setPlainCode }: { setPlainCode: (value: Rea
       const codeData = await getUserCodes();
       show({ hide, codeData, setPlainCode });
     } catch (err) {
-      if (isAxiosError(err) && err.response && err.response.status === 401) {
-        showLoginModal({ hideLoginModal });
+      if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
+        showLoginModal({ code: plainCode });
       }
     }
   };

--- a/frontEnd/src/components/room/modal/LoginModal.tsx
+++ b/frontEnd/src/components/room/modal/LoginModal.tsx
@@ -1,7 +1,11 @@
 import { useParams } from 'react-router-dom';
 
-export default function LoginModal() {
+export default function LoginModal({ code }: { code: string }) {
   const { roomId } = useParams();
+
+  const handleClick = () => {
+    localStorage.setItem('code', code);
+  };
 
   return (
     <div className="flex items-center justify-center gap-8 min-w-[600px]">
@@ -14,6 +18,7 @@ export default function LoginModal() {
           <div className="flex flex-col justify-between h-full gap-4">
             <a
               href={`https://api.algoitni.site/auth/github?next=${roomId}`}
+              onClick={handleClick}
               className="flex items-center p-4 text-white bg-black rounded-full"
             >
               <img src="/github.png" className="w-8 h-8" alt="github" />

--- a/frontEnd/src/components/room/modal/LoginModal.tsx
+++ b/frontEnd/src/components/room/modal/LoginModal.tsx
@@ -1,4 +1,8 @@
+import { useParams } from 'react-router-dom';
+
 export default function LoginModal() {
+  const { roomId } = useParams();
+
   return (
     <div className="flex items-center justify-center gap-8 min-w-[600px]">
       <div className="relative flex items-center justify-center">
@@ -8,7 +12,10 @@ export default function LoginModal() {
         <h1 className="text-2xl font-bold">소셜로그인</h1>
         <div className="flex flex-col gap-4">
           <div className="flex flex-col justify-between h-full gap-4">
-            <a href="https://api.algoitni.site/auth/github" className="flex items-center p-4 text-white bg-black rounded-full">
+            <a
+              href={`https://api.algoitni.site/auth/github?next=${roomId}`}
+              className="flex items-center p-4 text-white bg-black rounded-full"
+            >
               <img src="/github.png" className="w-8 h-8" alt="github" />
               <span className="text-xl font-bold px-11 basis-[90%]">Github Login</span>
             </a>

--- a/frontEnd/src/components/room/modal/SaveModal.tsx
+++ b/frontEnd/src/components/room/modal/SaveModal.tsx
@@ -11,7 +11,7 @@ export default function SaveModal({ hide, code }: { hide: () => void; code: stri
   const { inputValue, onChange } = useInput('');
   const ref = useFocus<HTMLInputElement>();
   const { show: showSuccessModal, hide: hideSuccessModal } = useModal(SuccessModal);
-  const { show: showLoginModal, hide: hideLoginModal } = useModal(LoginModal);
+  const { show: showLoginModal } = useModal(LoginModal);
 
   const handleClick = async () => {
     if (!inputValue) {
@@ -23,8 +23,8 @@ export default function SaveModal({ hide, code }: { hide: () => void; code: stri
       await postUserCode(inputValue, code);
       showSuccessModal({ hide: hideSuccessModal });
     } catch (err) {
-      if (isAxiosError(err) && err.response && err.response.status === 401) {
-        showLoginModal({ hide: hideLoginModal });
+      if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
+        showLoginModal({ code });
       }
     }
   };

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -10,10 +10,10 @@ import ChattingSection from '@/components/room/ChattingSection';
 import ControllSection from '@/components/room/ControllSection';
 
 export default function Room() {
-  const code = localStorage.getItem('code');
+  const defaultCode = localStorage.getItem('code');
   const { roomId } = useParams();
   const mediaObject = useMedia();
-  const [isSetting, setSetting] = useState(!!code || code === '');
+  const [isSetting, setSetting] = useState(!!defaultCode || defaultCode === '');
   const { streamList, dataChannels } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream, isSetting);
 
   if (!isSetting) return <Setting mediaObject={mediaObject} setSetting={setSetting} />;
@@ -30,7 +30,7 @@ export default function Room() {
               <QuizViewSection />
               <ControllSection mediaObject={mediaObject} />
             </div>
-            <EditorSection dataChannels={dataChannels} />
+            <EditorSection defaultCode={defaultCode} dataChannels={dataChannels} />
           </div>
         </div>
         <div className="flex basis-3/12">

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -10,9 +10,10 @@ import ChattingSection from '@/components/room/ChattingSection';
 import ControllSection from '@/components/room/ControllSection';
 
 export default function Room() {
+  const code = localStorage.getItem('code');
   const { roomId } = useParams();
   const mediaObject = useMedia();
-  const [isSetting, setSetting] = useState(false);
+  const [isSetting, setSetting] = useState(!!code || code === '');
   const { streamList, dataChannels } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream, isSetting);
 
   if (!isSetting) return <Setting mediaObject={mediaObject} setSetting={setSetting} />;


### PR DESCRIPTION
## PR 설명
- PR에 관한 간단한 설명

## ✅ 완료한 기능 명세
- [x] 403오류라도 로그인 모달을 띄우도록 변경
- [x] 리다이렉션시 코드가 날아가는 문제 해결
- [x] 리다이렉션 주소를 쿼리 파라미터로 넘기기


## 고민과 해결과정

로그인 버튼을 누를때, 해당 코드를 localStorage에 잠시 저장한 후, 리다이렉션이 되면 room에서 localStorage의 값을 검사하고, 값이 있다면 setting창을 보여주지 않고 바로 방에 재참여시키도록 했다.

참여가 완료되면 코드를 복구하고, localStorage를 비우는식으로 구현했다.