### PR TITLE
[FE] feat: react-query 적용

### DIFF
--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front-end",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.8.7",
         "axios": "^1.6.2",
         "dompurify": "^3.0.6",
         "highlight.js": "^11.9.0",
@@ -2012,6 +2013,40 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.8.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.8.7.tgz",
+      "integrity": "sha512-58xOSkxxZK4SGQ/uzX8MDZHLGZCkxlgkPxnfhxUOL2uchnNHyay2UVcR3mQNMgaMwH1e2l+0n+zfS7+UJ/MAJw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.8.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.8.7.tgz",
+      "integrity": "sha512-RYSSMmkhbJ7tPkf8w+MSRIXQLoUCm7DRnTLDcdf+uampupnriEsob3fVWTt9oaEj+AJWEKeCErDBdZeNcAzURQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.8.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.3",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.8.7",
     "axios": "^1.6.2",
     "dompurify": "^3.0.6",
     "highlight.js": "^11.9.0",

--- a/frontEnd/src/components/room/editor/LoadButton.tsx
+++ b/frontEnd/src/components/room/editor/LoadButton.tsx
@@ -6,6 +6,7 @@ import { uploadLocalFile } from '@/utils/file';
 import CodeListModal from '../modal/CodeListModal';
 import LoginModal from '../modal/LoginModal';
 import createAuthFailCallback from '@/utils/authFailCallback';
+import QUERY_KEYS from '@/constants/queryKeys';
 
 function LoadButtonElement({ children, onClick }: { children: React.ReactNode; onClick: React.MouseEventHandler<HTMLButtonElement> }) {
   return (
@@ -28,7 +29,7 @@ export default function LoadButton({
   const { show } = useModal(CodeListModal);
   const { show: showLoginModal } = useModal(LoginModal);
   const { data, isError, error, refetch } = useQuery({
-    queryKey: ['codesData'],
+    queryKey: [QUERY_KEYS.LOAD_CODES],
     queryFn: getUserCodes,
     enabled: false,
   });

--- a/frontEnd/src/components/room/editor/LoadButton.tsx
+++ b/frontEnd/src/components/room/editor/LoadButton.tsx
@@ -1,9 +1,11 @@
-import { isAxiosError } from 'axios';
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import getUserCodes from '@/apis/getUserCodes';
 import useModal from '@/hooks/useModal';
 import { uploadLocalFile } from '@/utils/file';
 import CodeListModal from '../modal/CodeListModal';
 import LoginModal from '../modal/LoginModal';
+import createAuthFailCallback from '@/utils/authFailCallback';
 
 function LoadButtonElement({ children, onClick }: { children: React.ReactNode; onClick: React.MouseEventHandler<HTMLButtonElement> }) {
   return (
@@ -25,20 +27,24 @@ export default function LoadButton({
 }) {
   const { show } = useModal(CodeListModal);
   const { show: showLoginModal } = useModal(LoginModal);
+  const { data, isError, error, refetch } = useQuery({
+    queryKey: ['codesData'],
+    queryFn: getUserCodes,
+    enabled: false,
+  });
+  const errorCallback = createAuthFailCallback(() => showLoginModal({ code: plainCode }));
+
+  useEffect(() => {
+    if (data) show({ codeData: data, setPlainCode });
+    if (isError) errorCallback(error);
+  }, [data, isError]);
 
   const handleLoadLocalCodeFile = () => {
     uploadLocalFile((result) => setPlainCode(result));
   };
 
   const handleLoadCloudCodeFile = async () => {
-    try {
-      const codeData = await getUserCodes();
-      show({ codeData, setPlainCode });
-    } catch (err) {
-      if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
-        showLoginModal({ code: plainCode });
-      }
-    }
+    refetch();
   };
   return (
     <div className="relative h-full">

--- a/frontEnd/src/components/room/modal/SaveModal.tsx
+++ b/frontEnd/src/components/room/modal/SaveModal.tsx
@@ -1,4 +1,4 @@
-import { isAxiosError } from 'axios';
+import { useMutation } from '@tanstack/react-query';
 import Button from '@/components/common/Button';
 import useFocus from '@/hooks/useFocus';
 import useInput from '@/hooks/useInput';
@@ -6,13 +6,26 @@ import useModal from '@/hooks/useModal';
 import SuccessModal from './SuccessModal';
 import LoginModal from './LoginModal';
 import postUserCode from '@/apis/postUserCode';
+import reactQueryClient from '@/configs/reactQueryClient';
+import createAuthFailCallback from '@/utils/authFailCallback';
 
 export default function SaveModal({ code }: { code: string }) {
   const { inputValue, onChange } = useInput('');
   const ref = useFocus<HTMLInputElement>();
-  const { show: showSuccessModal, hide: hideSuccessModal } = useModal(SuccessModal);
+  const { show: showSuccessModal } = useModal(SuccessModal);
   const { show: showLoginModal } = useModal(LoginModal);
   const { hide } = useModal();
+
+  const mutationSuccess = () => {
+    showSuccessModal();
+    reactQueryClient.invalidateQueries({ queryKey: ['codesData'] });
+  };
+
+  const { mutate } = useMutation({
+    mutationFn: () => postUserCode(inputValue, code),
+    onSuccess: () => mutationSuccess,
+    onError: createAuthFailCallback(() => showLoginModal({ code })),
+  });
 
   const handleClick = async () => {
     if (!inputValue) {
@@ -20,14 +33,7 @@ export default function SaveModal({ code }: { code: string }) {
       return;
     }
     hide();
-    try {
-      await postUserCode(inputValue, code);
-      showSuccessModal({ hide: hideSuccessModal });
-    } catch (err) {
-      if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
-        showLoginModal({ code });
-      }
-    }
+    mutate();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => e.key === 'Enter' && handleClick();

--- a/frontEnd/src/components/room/modal/SaveModal.tsx
+++ b/frontEnd/src/components/room/modal/SaveModal.tsx
@@ -8,6 +8,7 @@ import LoginModal from './LoginModal';
 import postUserCode from '@/apis/postUserCode';
 import reactQueryClient from '@/configs/reactQueryClient';
 import createAuthFailCallback from '@/utils/authFailCallback';
+import QUERY_KEYS from '@/constants/queryKeys';
 
 export default function SaveModal({ code }: { code: string }) {
   const { inputValue, onChange } = useInput('');
@@ -18,7 +19,7 @@ export default function SaveModal({ code }: { code: string }) {
 
   const mutationSuccess = () => {
     showSuccessModal();
-    reactQueryClient.invalidateQueries({ queryKey: ['codesData'] });
+    reactQueryClient.invalidateQueries({ queryKey: [QUERY_KEYS.LOAD_CODES] });
   };
 
   const { mutate } = useMutation({

--- a/frontEnd/src/components/room/modal/tests/SaveModal.test.tsx
+++ b/frontEnd/src/components/room/modal/tests/SaveModal.test.tsx
@@ -1,6 +1,8 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import SaveModal from '../SaveModal';
 import { ModalHideContext } from '@/components/modal/Modal';
+import reactQueryClient from '@/configs/reactQueryClient';
 
 const hide = jest.fn();
 jest.mock('@/apis/postUserCode', () => {});
@@ -8,9 +10,12 @@ jest.mock('@/apis/postUserCode', () => {});
 describe('SaveModal기능테스트', () => {
   it('값이 없을때는 저장 버튼을 눌러도 제출하지 않는다.', () => {
     render(
-      <ModalHideContext.Provider value={hide}>
-        <SaveModal code="123" />
-      </ModalHideContext.Provider>,
+      <QueryClientProvider client={reactQueryClient}>
+        <ModalHideContext.Provider value={hide}>
+          <SaveModal code="123" />
+        </ModalHideContext.Provider>
+        ,
+      </QueryClientProvider>,
     );
     fireEvent.click(screen.getByText('저장하기'));
     expect(hide).toHaveBeenCalledTimes(0);
@@ -18,9 +23,11 @@ describe('SaveModal기능테스트', () => {
 
   it('값이 없을때는 엔터버튼을 눌러도 제출하지 않는다.', () => {
     render(
-      <ModalHideContext.Provider value={hide}>
-        <SaveModal code="123" />
-      </ModalHideContext.Provider>,
+      <QueryClientProvider client={reactQueryClient}>
+        <ModalHideContext.Provider value={hide}>
+          <SaveModal code="123" />
+        </ModalHideContext.Provider>
+      </QueryClientProvider>,
     );
     fireEvent.keyDown(screen.getByPlaceholderText('solution.py'), { key: 'Enter' });
     expect(hide).toHaveBeenCalledTimes(0);
@@ -28,9 +35,11 @@ describe('SaveModal기능테스트', () => {
 
   it('값이 있다면 저장 버튼을 눌렀을때 제출한다.', () => {
     render(
-      <ModalHideContext.Provider value={hide}>
-        <SaveModal code="123" />
-      </ModalHideContext.Provider>,
+      <QueryClientProvider client={reactQueryClient}>
+        <ModalHideContext.Provider value={hide}>
+          <SaveModal code="123" />
+        </ModalHideContext.Provider>
+      </QueryClientProvider>,
     );
     fireEvent.change(screen.getByPlaceholderText('solution.py'), { target: { value: 'solution.py' } });
     fireEvent.click(screen.getByText('저장하기'));
@@ -39,9 +48,11 @@ describe('SaveModal기능테스트', () => {
 
   it('값이 있다면 엔터버튼을 눌렀을때 제출한다.', () => {
     render(
-      <ModalHideContext.Provider value={hide}>
-        <SaveModal code="123" />
-      </ModalHideContext.Provider>,
+      <QueryClientProvider client={reactQueryClient}>
+        <ModalHideContext.Provider value={hide}>
+          <SaveModal code="123" />
+        </ModalHideContext.Provider>
+      </QueryClientProvider>,
     );
     fireEvent.change(screen.getByPlaceholderText('solution.py'), { target: { value: 'solution.py' } });
     fireEvent.keyDown(screen.getByPlaceholderText('solution.py'), { key: 'Enter' });

--- a/frontEnd/src/configs/reactQueryClient.ts
+++ b/frontEnd/src/configs/reactQueryClient.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const reactQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+export default reactQueryClient;

--- a/frontEnd/src/constants/queryKeys.ts
+++ b/frontEnd/src/constants/queryKeys.ts
@@ -1,0 +1,4 @@
+const QUERY_KEYS = {
+  LOAD_CODES: 'codes',
+};
+export default QUERY_KEYS;

--- a/frontEnd/src/main.tsx
+++ b/frontEnd/src/main.tsx
@@ -1,9 +1,13 @@
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+
 import '@styles/index.css';
 import Home from '@pages/Home.tsx';
 import Room from '@pages/Room.tsx';
+
 import Modals from './components/modal/Modals';
+import reactQueryClient from './configs/reactQueryClient';
 
 const router = createBrowserRouter([
   {
@@ -15,12 +19,13 @@ const router = createBrowserRouter([
     element: <Room />,
   },
 ]);
+
 function Main() {
   return (
-    <>
+    <QueryClientProvider client={reactQueryClient}>
       <RouterProvider router={router} />
       <Modals />
-    </>
+    </QueryClientProvider>
   );
 }
 ReactDOM.createRoot(document.getElementById('root')!).render(<Main />);

--- a/frontEnd/src/pages/tests/Room.test.tsx
+++ b/frontEnd/src/pages/tests/Room.test.tsx
@@ -1,8 +1,10 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Socket } from 'socket.io-client/debug';
 import Room from '../Room';
 import * as useRTCConnection from '@/hooks/useRTCConnection';
 import * as useMedia from '@/hooks/useMedia';
+import reactQueryClient from '@/configs/reactQueryClient';
 
 const mockRoomData = {
   socket: {} as Socket,
@@ -29,12 +31,20 @@ describe('Room 조건부 렌더링 테스트', () => {
   jest.spyOn(useMedia, 'default').mockImplementation(() => mockMedia);
 
   it('Room에 처음 입장하면 Setting컴포넌트가 렌더링된다.', () => {
-    render(<Room />);
+    render(
+      <QueryClientProvider client={reactQueryClient}>
+        <Room />
+      </QueryClientProvider>,
+    );
     expect(screen.getByText('참여할 준비가 되셨나요?')).toBeTruthy();
   });
 
   it('Room에서 참여 버튼을 누르면 Setting 컴포넌트가 사라진다.', () => {
-    render(<Room />);
+    render(
+      <QueryClientProvider client={reactQueryClient}>
+        <Room />
+      </QueryClientProvider>,
+    );
     fireEvent.click(screen.getByText('참여'));
     expect(() => screen.getByText('참여할 준비가 되셨나요?')).toThrow();
   });

--- a/frontEnd/src/utils/authFailCallback.ts
+++ b/frontEnd/src/utils/authFailCallback.ts
@@ -1,0 +1,9 @@
+import { isAxiosError } from 'axios';
+
+export default function createAuthFailCallback(callback: () => void) {
+  return (err: Error) => {
+    if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
+      callback();
+    }
+  };
+}


### PR DESCRIPTION
## PR 설명
react-query 적용

## ✅ 완료한 기능 명세
- [x] react-query설치, 설정
- [x] 기존 fetch로직들 react-query 적용
- [x] queryKey상수로 관리


## 고민과 해결과정

### 왜 react-query인가?
클라이언트에서 서버 데이터를 저장하여 서버로 가는 api요청을 줄이고, 사용자가 빠르게 화면을 볼 수 있도록 할 수 있다.
우리 서비스의 경우, modal이 뜨기까지 사용자가 기다려야하는 문제가 있는데, react-query를 사용하면 이부분에 드는 시간을 최소화시킬 수 있다.

또한, 사용자가 자신의 코드를 업데이트 할때에만 stale처리를 해주면되므로, 관리도 간편하다.

### 에러처리
리액트 쿼리에서 공통 에러처리를 queryClient를 통해 할 수 있는데, 이부분에서 modal을띄워야하는 문제가 있었다.
일단은 failed Callback을 적용시키는 식으로 공통코드를 처리했다.

```typescript
import { isAxiosError } from 'axios';

export default function createAuthFailCallback(callback: () => void) {
  return (err: Error) => {
    if (isAxiosError(err) && err.response && (err.response.status === 401 || err.response.status === 403)) {
      callback();
    }
  };
}
```
이런식으로 처리해주었다.
```typescript
...
  const { data, isError, error, refetch } = useQuery({
    queryKey: [QUERY_KEYS.LOAD_CODES],
    queryFn: getUserCodes,
    enabled: false,
  });
  const errorCallback = createAuthFailCallback(() => showLoginModal({ code: plainCode }));

  useEffect(() => {
    if (data) show({ codeData: data, setPlainCode });
    if (isError) errorCallback(error);
  }, [data, isError]);
... 
```