### PR TITLE
[FE] fix: 파일 불러오기 모달이 안뜨는 이슈 해결시도

### DIFF
--- a/frontEnd/src/components/room/modal/CodeListModal.tsx
+++ b/frontEnd/src/components/room/modal/CodeListModal.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { LoadCodeData } from '@/types/loadCodeData';
 import CodeFileButton from './codeList/CodeFileButton';
 import Button from '@/components/common/Button';
 import useModal from '@/hooks/useModal';
 import WarningModal from './WarningModal';
+import getUserCodes from '@/apis/getUserCodes';
+import QUERY_KEYS from '@/constants/queryKeys';
 
 export default function CodeListModal({
   codeData,
@@ -12,12 +15,17 @@ export default function CodeListModal({
   codeData: LoadCodeData[];
   setPlainCode: (value: React.SetStateAction<string>) => void;
 }) {
+  const { data } = useQuery({
+    queryKey: [QUERY_KEYS.LOAD_CODES],
+    queryFn: getUserCodes,
+  });
+
   const [selectOne, setSelectOne] = useState<string>('');
   const { show } = useModal(WarningModal);
   const { hide } = useModal();
 
   const findById = (id: string) => {
-    const result = codeData.find((data) => data.id === id);
+    const result = codeData.find((code) => code.id === id);
     return result;
   };
 
@@ -28,13 +36,13 @@ export default function CodeListModal({
       show({ warningString: '작업중이던 내용이 모두 지워집니다.', callback: () => setPlainCode(result.content) });
     }
   };
-
+  const renderData = data || codeData;
   return (
     <div className="flex flex-col items-center justify-center w-full gap-4">
       <div className="w-full text-xl font-bold ">파일 불러오기</div>
       <div className="w-[70vw] h-[50vh] max-h-[50vh] overflow-y-auto border-y p-4">
         <div className="grid grid-cols-5 gap-4">
-          {codeData.map((code) => (
+          {renderData.map((code) => (
             <div key={code.id} className={code.id === selectOne ? 'bg-blue-100  rounded-xl py-4' : 'py-4'}>
               <CodeFileButton code={code} handleDoubleClick={handleClick} selectOne={selectOne} setSelectOne={setSelectOne} />
             </div>


### PR DESCRIPTION
## PR 설명
파일 불러오기 모달이 안뜨는 이슈 해결시도
useQuery를 modal 내부에서 실행하는 형태로 이슈 해결시도

## ✅ 완료한 기능 명세
- [x] useQuery를 modal 내부에서 실행하는 형태로 이슈 해결시도

## 고민과 해결과정

기존의 useQuery를 LoadButton에서 실행시켜서 모달이 바로 뜨지않고, 이후에 캐시가 stale되어도 모달 상태가 업데이트 되지 않을 수 있으므로 이부분을 그냥 요청을 1회 보내고, 모달을 띄운 후에 모달 내부의 데이터를 useQuery로 관리해주었다.