### PR TITLE
[BE] feature: 다른 언어 지원 기능 구현 - 코드 저장 및 실행

### DIFF
--- a/backEnd/api/src/auth/google/google.service.ts
+++ b/backEnd/api/src/auth/google/google.service.ts
@@ -20,7 +20,7 @@ export class GoogleService {
     this.oauth2Client = new google.auth.OAuth2(
       this.client_id,
       this.configService.get<string>('CLIENT_SECRET_GOOGLE'),
-      `${this.configService.get<string>('API_DOMAIN')}/google-callback`,
+      `${this.configService.get<string>('API_DOMAIN')}/auth/google-callback`,
     );
 
     this.authorizationUrl = this.oauth2Client.generateAuthUrl({

--- a/backEnd/api/src/codes/codes.controller.ts
+++ b/backEnd/api/src/codes/codes.controller.ts
@@ -62,7 +62,7 @@ export class CodesController {
   async update(
     @Req() req: Request,
     @Param('id') id: string,
-    @Body() saveCodeDto: SaveCodeDto,
+    @Body(SaveCodePipe) saveCodeDto: SaveCodeDto,
   ) {
     const user: UserInfoDto = req.user as UserInfoDto;
     const userID = user.id;

--- a/backEnd/api/src/codes/codes.controller.ts
+++ b/backEnd/api/src/codes/codes.controller.ts
@@ -19,6 +19,7 @@ import { ResourceNotFound } from '../common/exception/exception';
 import { Serialize } from '../common/interceptor/serialize.interceptor';
 import { SaveResultDto } from './dto/saveResult.dto';
 import { GetCodeDto } from './dto/getCode.dto';
+import { SaveCodePipe } from './pipes/saveCode.pipe';
 
 @UseGuards(JwtAuthGuard)
 @Controller('codes')
@@ -28,7 +29,10 @@ export class CodesController {
 
   @Post()
   @Serialize(SaveResultDto)
-  async save(@Body() saveCodeDto: SaveCodeDto, @Req() req: Request) {
+  async save(
+    @Body(SaveCodePipe) saveCodeDto: SaveCodeDto,
+    @Req() req: Request,
+  ) {
     const user: UserInfoDto = req.user as UserInfoDto;
     saveCodeDto.userID = user.id;
     return await this.codesService.save(saveCodeDto);

--- a/backEnd/api/src/codes/codes.module.ts
+++ b/backEnd/api/src/codes/codes.module.ts
@@ -5,6 +5,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Code, CodeSchema } from './schemas/code.schemas';
 import { AuthModule } from '../auth/auth.module';
+import { SaveCodePipe } from './pipes/saveCode.pipe';
 
 @Module({
   imports: [
@@ -22,6 +23,6 @@ import { AuthModule } from '../auth/auth.module';
     AuthModule,
   ],
   controllers: [CodesController],
-  providers: [CodesService],
+  providers: [CodesService, SaveCodePipe],
 })
 export class CodesModule {}

--- a/backEnd/api/src/codes/dto/getCode.dto.ts
+++ b/backEnd/api/src/codes/dto/getCode.dto.ts
@@ -1,4 +1,5 @@
 import { Expose } from 'class-transformer';
+import { supportLang } from '../../common/type';
 
 export class GetCodeDto {
   @Expose()
@@ -9,4 +10,7 @@ export class GetCodeDto {
 
   @Expose()
   content: string;
+
+  @Expose()
+  language: supportLang;
 }

--- a/backEnd/api/src/codes/dto/saveCode.dto.ts
+++ b/backEnd/api/src/codes/dto/saveCode.dto.ts
@@ -1,4 +1,5 @@
 import { IsString } from 'class-validator';
+import { supportLang } from '../../common/type';
 
 export class SaveCodeDto {
   userID?: number;
@@ -8,4 +9,7 @@ export class SaveCodeDto {
 
   @IsString()
   content: string;
+
+  @IsString()
+  language: supportLang;
 }

--- a/backEnd/api/src/codes/pipes/saveCode.pipe.ts
+++ b/backEnd/api/src/codes/pipes/saveCode.pipe.ts
@@ -1,0 +1,19 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import * as path from 'path';
+import { SaveCodeDto } from '../dto/saveCode.dto';
+import { ExtNameException } from '../../common/exception/exception';
+
+const languageExtName = {
+  '.js': 'javascript',
+  '.py': 'python',
+};
+
+@Injectable()
+export class SaveCodePipe implements PipeTransform {
+  transform(value: SaveCodeDto) {
+    if (languageExtName[path.extname(value.title)] !== value.language) {
+      throw new ExtNameException();
+    }
+    return value;
+  }
+}

--- a/backEnd/api/src/codes/schemas/code.schemas.ts
+++ b/backEnd/api/src/codes/schemas/code.schemas.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument } from 'mongoose';
+import { supportLang } from '../../common/type';
 
 export type CodeDocument = HydratedDocument<Code>;
 
@@ -13,6 +14,9 @@ export class Code {
 
   @Prop({ require: true })
   content: string;
+
+  @Prop({ require: true, default: 'python' })
+  language: supportLang;
 }
 
 export const CodeSchema = SchemaFactory.createForClass(Code);

--- a/backEnd/api/src/common/exception/exception.ts
+++ b/backEnd/api/src/common/exception/exception.ts
@@ -35,3 +35,9 @@ export class ResourceNotFound extends HttpException {
     super(message, HttpStatus.BAD_REQUEST);
   }
 }
+
+export class ExtNameException extends HttpException {
+  constructor(message = '저장 파일의 확장자와 설정 언어가 일치하지 않습니다.') {
+    super(message, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/backEnd/api/src/common/type.ts
+++ b/backEnd/api/src/common/type.ts
@@ -1,0 +1,1 @@
+export type supportLang = 'python' | 'javascript';

--- a/backEnd/api/src/common/utils.ts
+++ b/backEnd/api/src/common/utils.ts
@@ -1,7 +1,13 @@
 import * as process from 'process';
+import { supportLang } from './type';
+export const supportLangEnum = {
+  PYTHON: 'python',
+  JAVASCRIPT: 'javascript',
+};
 
-export const requestPath = {
-  RUN_PYTHON: '/codes/python',
+export const requestPath: Record<supportLang, string> = {
+  python: '/codes/python',
+  javascript: '/codes/js',
 };
 
 const timeUnit = {

--- a/backEnd/api/src/common/utils.ts
+++ b/backEnd/api/src/common/utils.ts
@@ -59,6 +59,7 @@ export const jwtError = {
 export const ResponseMessage = {
   NEED_LOGIN: '로그인이 필요합니다.',
   INTERNAL_SERVER_ERROR: 'Internal server error',
+  NOT_SUPPORT: '지원하지 않는 언어 타입입니다.',
 };
 
 export const SOCKET_EVENT = {

--- a/backEnd/api/src/mq/mq.service.ts
+++ b/backEnd/api/src/mq/mq.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { ConfigService } from '@nestjs/config';
-import { RequestCodeblockDto } from '../run/dto/request-codeblock.dto';
+import { RequestCodeBlockDto } from '../run/dto/request-codeblock.dto';
 import Redis from 'ioredis';
 import { EVENT, REDIS } from '../common/utils';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -47,7 +47,7 @@ export class MqService {
     });
   }
 
-  async addMessage(data: RequestCodeblockDto) {
+  async addMessage(data: RequestCodeBlockDto) {
     const job = await this.queue.add(REDIS.QUEUE, data, {
       removeOnComplete: true,
     });

--- a/backEnd/api/src/mq/mq.service.ts
+++ b/backEnd/api/src/mq/mq.service.ts
@@ -48,7 +48,7 @@ export class MqService {
   }
 
   async addMessage(data: RequestCodeblockDto) {
-    const job = await this.queue.add(REDIS.QUEUE, data.code, {
+    const job = await this.queue.add(REDIS.QUEUE, data, {
       removeOnComplete: true,
     });
     this.logger.log(`push to task Queue ${job.id}`);

--- a/backEnd/api/src/run/dto/request-codeblock.dto.ts
+++ b/backEnd/api/src/run/dto/request-codeblock.dto.ts
@@ -1,7 +1,7 @@
 import { IsString } from 'class-validator';
 import { supportLang } from '../../common/type';
 
-export class RequestCodeblockDto {
+export class RequestCodeBlockDto {
   @IsString()
   code: string;
 

--- a/backEnd/api/src/run/dto/request-codeblock.dto.ts
+++ b/backEnd/api/src/run/dto/request-codeblock.dto.ts
@@ -1,6 +1,10 @@
 import { IsString } from 'class-validator';
+import { supportLang } from '../../common/type';
 
 export class RequestCodeblockDto {
   @IsString()
   code: string;
+
+  @IsString()
+  language: supportLang;
 }

--- a/backEnd/api/src/run/pipes/saveCode.pipe.ts
+++ b/backEnd/api/src/run/pipes/saveCode.pipe.ts
@@ -1,0 +1,14 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { ExtNameException } from '../../common/exception/exception';
+import { RequestCodeBlockDto } from '../dto/request-codeblock.dto';
+import { ResponseMessage } from '../../common/utils';
+
+@Injectable()
+export class RequestRunPipe implements PipeTransform {
+  transform(value: RequestCodeBlockDto) {
+    if (!['python', 'javascript'].includes(value.language)) {
+      throw new ExtNameException(ResponseMessage.NOT_SUPPORT);
+    }
+    return value;
+  }
+}

--- a/backEnd/api/src/run/run.controller.ts
+++ b/backEnd/api/src/run/run.controller.ts
@@ -18,7 +18,6 @@ export class RunController {
   @Post('v1')
   async requestRunCode(@Body() codeBlock: RequestCodeblockDto) {
     this.securityCheck(codeBlock);
-
     const responseCodeBlockDto =
       await this.runService.requestRunningApi(codeBlock);
     return responseCodeBlockDto;

--- a/backEnd/api/src/run/run.controller.ts
+++ b/backEnd/api/src/run/run.controller.ts
@@ -1,10 +1,11 @@
 import { Body, Controller, Get, HttpCode, Post, Query } from '@nestjs/common';
 import { RunService } from './run.service';
-import { RequestCodeblockDto } from './dto/request-codeblock.dto';
+import { RequestCodeBlockDto } from './dto/request-codeblock.dto';
 import { returnCode } from '../common/returnCode';
 import { VulnerableException } from '../common/exception/exception';
 import { MqService } from '../mq/mq.service';
 import { RedisService } from '../redis/redis.service';
+import { RequestRunPipe } from './pipes/saveCode.pipe';
 
 @Controller('run')
 export class RunController {
@@ -16,7 +17,7 @@ export class RunController {
   ) {}
   @HttpCode(200)
   @Post('v1')
-  async requestRunCode(@Body() codeBlock: RequestCodeblockDto) {
+  async requestRunCode(@Body(RequestRunPipe) codeBlock: RequestCodeBlockDto) {
     this.securityCheck(codeBlock);
     const responseCodeBlockDto =
       await this.runService.requestRunningApi(codeBlock);
@@ -25,7 +26,7 @@ export class RunController {
 
   @HttpCode(200)
   @Post('v2')
-  async requestRunCodeV2(@Body() codeBlock: RequestCodeblockDto) {
+  async requestRunCodeV2(@Body(RequestRunPipe) codeBlock: RequestCodeBlockDto) {
     this.securityCheck(codeBlock);
 
     const responseCodeBlockDto =
@@ -38,14 +39,14 @@ export class RunController {
   @Post('v3')
   async requestRunCodeV3(
     @Query('id') socketID: string,
-    @Body() codeBlock: RequestCodeblockDto,
+    @Body(RequestRunPipe) codeBlock: RequestCodeBlockDto,
   ): Promise<void> {
     this.securityCheck(codeBlock);
 
     await this.runService.requestRunningMQPubSub(codeBlock, socketID);
   }
 
-  securityCheck(codeBlock: RequestCodeblockDto) {
+  securityCheck(codeBlock: RequestCodeBlockDto) {
     const { code, language } = codeBlock;
     const securityCheck = this.runService.securityCheck(code, language);
 

--- a/backEnd/api/src/run/run.service.ts
+++ b/backEnd/api/src/run/run.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { returnCode } from '../common/returnCode';
-import { RequestCodeblockDto } from './dto/request-codeblock.dto';
+import { RequestCodeBlockDto } from './dto/request-codeblock.dto';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 import { requestPath } from '../common/utils';
@@ -75,7 +75,7 @@ export class RunService {
   }
 
   async requestRunningApi(
-    codeBlock: RequestCodeblockDto,
+    codeBlock: RequestCodeBlockDto,
   ): Promise<ResponseCodeBlockDto> {
     const url =
       'http://' +
@@ -105,7 +105,7 @@ export class RunService {
   }
 
   async requestRunningMQ(
-    codeBlock: RequestCodeblockDto,
+    codeBlock: RequestCodeBlockDto,
   ): Promise<ResponseCodeBlockDto> {
     const job = await this.mqService.addMessage(codeBlock);
     this.logger.log(`added message queue job#${job.id}`);
@@ -120,7 +120,7 @@ export class RunService {
     return result;
   }
   async requestRunningMQPubSub(
-    codeBlock: RequestCodeblockDto,
+    codeBlock: RequestCodeBlockDto,
     socketID: string,
   ): Promise<void> {
     const job = await this.mqService.addMessage(codeBlock);

--- a/backEnd/api/src/run/run.service.ts
+++ b/backEnd/api/src/run/run.service.ts
@@ -71,18 +71,23 @@ export class RunService {
   }
 
   javascriptCheck(code: string) {
-    return returnCode['vulnerable'];
+    return returnCode['safe'];
   }
 
   async requestRunningApi(
     codeBlock: RequestCodeblockDto,
   ): Promise<ResponseCodeBlockDto> {
+    console.log(
+      this.configService.get<string>('RUNNING_SERVER'),
+      requestPath[codeBlock.language],
+    );
     const url =
       'http://' +
       path.join(
         this.configService.get<string>('RUNNING_SERVER'),
         requestPath[codeBlock.language],
       );
+
     try {
       const result = await axios.post(url, codeBlock);
       return new ResponseCodeBlockDto(

--- a/backEnd/api/src/run/run.service.ts
+++ b/backEnd/api/src/run/run.service.ts
@@ -77,10 +77,6 @@ export class RunService {
   async requestRunningApi(
     codeBlock: RequestCodeblockDto,
   ): Promise<ResponseCodeBlockDto> {
-    console.log(
-      this.configService.get<string>('RUNNING_SERVER'),
-      requestPath[codeBlock.language],
-    );
     const url =
       'http://' +
       path.join(
@@ -120,7 +116,7 @@ export class RunService {
       this.logger.error(`${job.id} failed to find completed job : ${result}`);
       throw new TimeoutCodeRunning();
     }
-    this.logger.log(`get completed result ${result}`);
+    this.logger.log(`get completed result ${JSON.stringify(result)}`);
     return result;
   }
   async requestRunningMQPubSub(

--- a/backEnd/running/src/codes/codes.controller.ts
+++ b/backEnd/running/src/codes/codes.controller.ts
@@ -7,13 +7,13 @@ export class CodesController {
   constructor(private readonly codesService: CodesService) {}
 
   @Post('/python')
-  async runPython(@Body() data: RequestCodeDto) {
-    return await this.codesService.testCode(data.code);
+  async runPython(@Body() codeBlock: RequestCodeDto) {
+    console.log(codeBlock);
+    return await this.codesService.runCode(codeBlock);
   }
 
-  @Post('/test')
-  async test() {
-    const code = 'N,M = 5,6; print(N+M)';
-    return await this.codesService.testCode(code);
+  @Post('/js')
+  async runJavascript(@Body() codeBlock: RequestCodeDto) {
+    return await this.codesService.runCode(codeBlock);
   }
 }

--- a/backEnd/running/src/codes/codes.controller.ts
+++ b/backEnd/running/src/codes/codes.controller.ts
@@ -8,7 +8,6 @@ export class CodesController {
 
   @Post('/python')
   async runPython(@Body() codeBlock: RequestCodeDto) {
-    console.log(codeBlock);
     return await this.codesService.runCode(codeBlock);
   }
 

--- a/backEnd/running/src/codes/codes.service.ts
+++ b/backEnd/running/src/codes/codes.service.ts
@@ -11,10 +11,12 @@ import { exec } from 'child_process';
 import { LanguageCommand, Messages } from '../common/utils';
 import { supportLang, runCommandResult } from '../common/type';
 import { RequestCodeDto } from './dto/request-code.dto';
+import * as process from 'process';
 @Injectable()
 export class CodesService {
   private logger = new Logger(CodesService.name);
-  private tempDir = path.join(__dirname, '..', 'tmp');
+  private tempDir =
+    process.env.NODE_ENV === 'dev' ? path.join(__dirname, '..', 'tmp') : '/';
   private killSignal: NodeJS.Signals = 'SIGINT';
   private readonly timeOut = 5000;
 

--- a/backEnd/running/src/codes/dto/request-code.dto.ts
+++ b/backEnd/running/src/codes/dto/request-code.dto.ts
@@ -1,3 +1,10 @@
+import { IsString } from 'class-validator';
+import { supportLang } from '../../common/type';
+
 export class RequestCodeDto {
+  @IsString()
   code: string;
+
+  @IsString()
+  language: supportLang;
 }

--- a/backEnd/running/src/codes/dto/response-code.dto .ts
+++ b/backEnd/running/src/codes/dto/response-code.dto .ts
@@ -1,3 +1,3 @@
 export class ResponseCodeDto {
-  output: string[];
+  output: string;
 }

--- a/backEnd/running/src/common/type.ts
+++ b/backEnd/running/src/common/type.ts
@@ -1,0 +1,2 @@
+export type supportLang = 'python' | 'javascript';
+export type runCommandResult = { stdout: string; stderr: string };

--- a/backEnd/running/src/common/utils.ts
+++ b/backEnd/running/src/common/utils.ts
@@ -2,6 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as process from 'process';
+import { supportLang } from './type';
 
 export const ERRORS = {
   REQUEST_INVALID: {
@@ -15,4 +16,14 @@ export const execPromise = promisify(exec);
 export const REDIS = {
   CHANNEL: 'completed',
   QUEUE: process.env.NODE_ENV === 'dev' ? 'task-dev' : 'task',
+};
+
+export const Messages = {
+  TIMEOUT: '코드가 실행되는데 너무 오래 걸립니다.',
+  UNKNOWN: '알 수 없는 에러가 발생했습니다.',
+};
+
+export const LanguageCommand: Record<supportLang, string> = {
+  python: 'python3',
+  javascript: 'node',
 };

--- a/backEnd/running/src/mq/dto/response-codeblock.dto.ts
+++ b/backEnd/running/src/mq/dto/response-codeblock.dto.ts
@@ -1,7 +1,7 @@
 export class ResponseCodeBlockDto {
   jobID?: string | number;
   statusCode: number;
-  result: string | string[];
+  result: string;
   message: string;
   timestamp: string;
   constructor() {

--- a/backEnd/running/src/mq/mq.consumer.ts
+++ b/backEnd/running/src/mq/mq.consumer.ts
@@ -12,7 +12,7 @@ export class MqConsumer {
   private logger = new Logger(MqConsumer.name);
   private errorMessage = {
     400: 'Failed to Run Code',
-    201: 'Running Python Code Success',
+    201: 'Running Code Success',
   };
   constructor(
     private redisService: RedisService,
@@ -20,15 +20,15 @@ export class MqConsumer {
   ) {}
   @Process(REDIS.QUEUE)
   async getMessageQueue(job: Job) {
-    this.logger.debug(`getMessageQueue ${job.id}, ${job.data}`);
+    this.logger.debug(`getMessageQueue ${job.id}, ${job.data.code}`);
     let result: ResponseCodeDto | string;
     const responseCodeBlockDTO = new ResponseCodeBlockDto();
 
     try {
       result = await this.codesService.runCode(job.data);
-      const output: string | string[] =
+      const output: string =
         typeof result === 'string' ? result : result.output;
-      this.logger.debug(JSON.stringify(result));
+      this.logger.debug(result);
 
       responseCodeBlockDTO.statusCode = HttpStatus.CREATED;
       responseCodeBlockDTO.result = output;

--- a/backEnd/running/src/mq/mq.consumer.ts
+++ b/backEnd/running/src/mq/mq.consumer.ts
@@ -25,7 +25,7 @@ export class MqConsumer {
     const responseCodeBlockDTO = new ResponseCodeBlockDto();
 
     try {
-      result = await this.codesService.testCode(job.data);
+      result = await this.codesService.runCode(job.data);
       const output: string | string[] =
         typeof result === 'string' ? result : result.output;
       this.logger.debug(JSON.stringify(result));


### PR DESCRIPTION
## PR 설명
다른 언어를 지원하기 위해서 기존 코드 수정
- 코드 수정이 일어난 기능 : 코드 저장, 실행

## ✅ 완료한 기능 명세
- [x] 코드 저장, 수정 시 코드 언어 정보도 함께 저장
- [x] 코드 실행시 언어 정보도 함께 요청받게 수정
- [x] javascript 실행 command 추가

## 고민과 해결과정
아직 Javascript 언어에 대한 에러 메세지 파싱, 보안 검사 로직은 추가되지 않았습니다.
그래서 javascipt 코드에서 에러가 발생하는 요청을 보내면 항상 알 수 없는 에러가 발생하는 상태입니다.

지원하는 언어를 문자 리터럴 타입으로 정의해서 검증합니다.
```javascipt
export type supportLang = 'python' | 'javascript';
```
## 리팩토링
자식 프로세스로 파일 실행 후 에러를 처리하는 과정에서 한 함수 내부에서 에러를 검증하고 다시 던지고 캐치하는 코드를 줄이는 방향으로 리팩토링을 진행했습니다.
```
    fs.writeFileSync(filePath, code);
    const { stdout, stderr } = await this.runCommand(filePath, language);
    if (stderr) {
      if (stderr === Messages.UNKNOWN) {
        throw new InternalServerErrorException();
      }
      const errorMessage = this.getErrorMessage(stderr);
      throw new RunningException(errorMessage);
    }
    fs.unlinkSync(filePath);
    return this.getOutput(stdout);
```
자식프로세스로 실행한 것에대한 에러는 실제 node 에러가 발생하지 않고 stderr에 담기므로 따로 처리해주지 않아도 되었고,
그 이외에 fs 모듈에서 발생하는 것들은 exception.filter에서 처리합니다.