### PR TITLE
[FE] refactor: highlight.js 사용하는 언어만 import 하도록 수정

### DIFF
--- a/frontEnd/src/configs/highlightCodeConfig.ts
+++ b/frontEnd/src/configs/highlightCodeConfig.ts
@@ -1,0 +1,8 @@
+import codeHighlighter from 'highlight.js/lib/core';
+import python from 'highlight.js/lib/languages/python';
+import javascript from 'highlight.js/lib/languages/javascript';
+
+codeHighlighter.registerLanguage('python', python);
+codeHighlighter.registerLanguage('javascript', javascript);
+
+export default codeHighlighter;

--- a/frontEnd/src/utils/highlightCode.ts
+++ b/frontEnd/src/utils/highlightCode.ts
@@ -1,7 +1,7 @@
-import hljs from 'highlight.js';
+import codeHighlighter from '@/configs/highlightCodeConfig';
 
 const highlightCode = (language: string, code: string) => {
-  return hljs.highlight(code, { language }).value.replace(/" "/g, '&nbsp; ');
+  return codeHighlighter.highlight(code, { language }).value.replace(/" "/g, '&nbsp; ');
 };
 
 export default highlightCode;


### PR DESCRIPTION
## PR 설명
- 번들링 크기를 줄이기 위해 highlight.js에서 사용하는 언어만 import 하도록 수정

## ✅ 완료한 기능 명세
- [x]  highlight.js에서 사용하는 언어만 import 하도록 수정

## 📸 스크린샷
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/45cb02d1-37fb-4dc9-b7e5-5dce9e20a63b)
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/03b54903-ad33-4bd4-a351-819785405626)

## 고민과 해결과정
- [📦 번들링 크기 줄이기](https://github.com/boostcampwm2023/web05-AlgoITNi/wiki/%F0%9F%93%A6-%EB%B2%88%EB%93%A4%EB%A7%81-%ED%81%AC%EA%B8%B0-%EC%A4%84%EC%9D%B4%EA%B8%B0)