### PR TITLE
[FE] feat: QuizSection, ControllSection, Modal 렌더링 최적화

### DIFF
--- a/frontEnd/src/components/modal/Modals.tsx
+++ b/frontEnd/src/components/modal/Modals.tsx
@@ -5,7 +5,10 @@ import Modal from './Modal';
 const portalElement = document.getElementById('modal') as HTMLElement;
 
 export default function Modals() {
-  const { modals, hideModal } = useModalState((state) => state);
+  const {
+    modals,
+    actions: { hideModal },
+  } = useModalState((state) => state);
   return createPortal(
     <>
       {modals.map((id) => (

--- a/frontEnd/src/components/room/QuizViewSection.tsx
+++ b/frontEnd/src/components/room/QuizViewSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, memo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import useModal from '@/hooks/useModal';
 import LinkInputModal from './modal/LinkInputModal';
@@ -9,17 +9,18 @@ import ClickToQuizInput from './quizView/ClickToQuizInput';
 import QuizIframe from './quizView/QuizIframe';
 import Loading from './quizView/Loading';
 
-export default function QuizViewSection() {
+function QuizViewSection() {
   const [url, setURL] = useState('');
   const { show: showLinkInputModal } = useModal(LinkInputModal);
   const { data, isLoading } = useQuery({ queryKey: [QUERY_KEYS, url], queryFn: () => getQuizData(url), enabled: !!url });
+  const handleClick = useCallback(() => showLinkInputModal({ setURL }), []);
 
   if (url === '' && !data)
     return (
       <button
         type="button"
         className="flex items-center justify-center w-full h-full text-white rounded-lg bg-primary "
-        onClick={() => showLinkInputModal({ setURL })}
+        onClick={handleClick}
       >
         <ClickToQuizInput />
       </button>
@@ -30,7 +31,7 @@ export default function QuizViewSection() {
   return (
     <div className="flex flex-col w-full h-full gap-2 p-4 rounded-lg ovelrflow-hidden bg-primary">
       <div className="flex justify-end w-full">
-        <Button.Dark fontSize="0.8rem" onClick={() => showLinkInputModal({ setURL })}>
+        <Button.Dark fontSize="0.8rem" onClick={handleClick}>
           변경하기
         </Button.Dark>
       </div>
@@ -38,3 +39,4 @@ export default function QuizViewSection() {
     </div>
   );
 }
+export default memo(QuizViewSection);

--- a/frontEnd/src/hooks/useModal.ts
+++ b/frontEnd/src/hooks/useModal.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useCallback } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import useModalState, { MODAL_COMPONENTS } from '@/stores/useModalState';
 import { ModalHideContext } from '@/components/modal/Modal';
@@ -22,16 +22,16 @@ function useModal<P extends Record<string, unknown>>(Component?: React.Component
     };
   }, [modalId]);
 
-  const show = useCallback((props?: P) => {
+  const show = (props?: P) => {
     if (!Component) return;
     MODAL_COMPONENTS[modalId].props = props;
     showModal(modalId);
-  }, []);
+  };
 
-  const hide = useCallback(() => {
+  const hide = () => {
     if (Component) hideModal(modalId);
     else hideThisModal();
-  }, []);
+  };
 
   if (Component) return { show, hide };
   return { hide };

--- a/frontEnd/src/hooks/useModal.ts
+++ b/frontEnd/src/hooks/useModal.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import useModalState, { MODAL_COMPONENTS } from '@/stores/useModalState';
 import { ModalHideContext } from '@/components/modal/Modal';
@@ -10,7 +10,7 @@ function useModal(): CalledByModalInner;
 function useModal<P extends Record<string, unknown>>(Component?: React.ComponentType<P>): CalledByModalOuter<P>;
 
 function useModal<P extends Record<string, unknown>>(Component?: React.ComponentType<P>): CalledByModalInner | CalledByModalOuter<P> {
-  const { showModal, hideModal } = useModalState((state) => state);
+  const { showModal, hideModal } = useModalState((state) => state.actions);
   const [modalId] = useState(uuidv4());
   // Modals에서 주입시킨 Provider로부터 Modal에 애니메이션을 적용시키는 함수 Context를 가져온다.
   const hideThisModal = useContext(ModalHideContext);
@@ -22,16 +22,16 @@ function useModal<P extends Record<string, unknown>>(Component?: React.Component
     };
   }, [modalId]);
 
-  const show = (props?: P) => {
+  const show = useCallback((props?: P) => {
     if (!Component) return;
     MODAL_COMPONENTS[modalId].props = props;
     showModal(modalId);
-  };
+  }, []);
 
-  const hide = () => {
+  const hide = useCallback(() => {
     if (Component) hideModal(modalId);
     else hideThisModal();
-  };
+  }, []);
 
   if (Component) return { show, hide };
   return { hide };

--- a/frontEnd/src/stores/useModalState.ts
+++ b/frontEnd/src/stores/useModalState.ts
@@ -5,23 +5,27 @@ export const MODAL_COMPONENTS: { [id: string]: { Component: React.ComponentType<
 
 type ModalState = {
   modals: string[];
-  showModal: (id: string) => void;
-  hideModal: (id: string) => void;
+  actions: {
+    showModal: (id: string) => void;
+    hideModal: (id: string) => void;
+  };
 };
 
 const useModalState = create<ModalState>((set) => ({
   modals: [],
-  showModal: (id: string) =>
-    set((state) => ({
-      ...state,
-      modals: [...state.modals, id],
-    })),
+  actions: {
+    showModal: (id: string) =>
+      set((state) => ({
+        ...state,
+        modals: [...state.modals, id],
+      })),
 
-  hideModal: (id: string) =>
-    set((state) => ({
-      ...state,
-      modals: [...state.modals.filter((modalId) => modalId !== id)],
-    })),
+    hideModal: (id: string) =>
+      set((state) => ({
+        ...state,
+        modals: [...state.modals.filter((modalId) => modalId !== id)],
+      })),
+  },
 }));
 
 export default useModalState;

--- a/frontEnd/vite.config.ts
+++ b/frontEnd/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
         target: 'https://api.algoitni.site/',
         changeOrigin: true,
       },
+      '/cache': {
+        target: 'https://api.algoitni.site/',
+        changeOrigin: true,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## PR 설명
QuizSection, ControllSection, Modal 렌더링 최적화
- #173 

## ✅ 완료한 기능 명세
- [x] QuizSection
- [x] ControllSection
- [x] Modal

## 📸 스크린샷

### 기존
https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/965c0d44-f464-47d4-b9ab-fa1a0d23a2b6

### 개선 후

https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/6fd39b02-41af-4646-811c-0c29a3d88b38


## 고민과 해결과정

### useModal최적화
Zustand의 전역상태인 useModalState를 사용하는 컴포넌트의 경우, modals 배열이 변경되면 전부 리렌더링되는 문제가 있었다.
이런 문제를 해결하기위해 Zustand의 state배열에 actions라는 객체를 만들고, 이걸 사용했다.
 actions의 주소값은 변하지 않기 때문에 렌더링 문제가 해결되었다.


### memo를 통한 메모이제이션
QuizSection의 경우, Room이 리렌더되어도(stream이 변하는경우) 다시 리렌더될 필요가 없다.
그래서 React.memo를 통해 메모이제이션을 해주었다.


