### PR TITLE
[FE] refactor: 리액트 쿼리 사용하여 code목록 캐싱 처리

### DIFF
--- a/frontEnd/src/components/room/modal/LoginModal.tsx
+++ b/frontEnd/src/components/room/modal/LoginModal.tsx
@@ -1,6 +1,9 @@
 import { ReactNode } from 'react';
 import { MODE } from '@/constants/env';
 import getDevCookie from '@/apis/getDevCookie';
+import reactQueryClient from '@/configs/reactQueryClient';
+import QUERY_KEYS from '@/constants/queryKeys';
+import useModal from '@/hooks/useModal';
 
 type LoginButtonWrapperProps = {
   handleClick: () => void;
@@ -27,12 +30,15 @@ function LoginButtonWrapper({ handleClick, className, type, children }: LoginBut
 }
 
 export default function LoginModal({ code }: { code: string }) {
+  const { hide } = useModal();
   const handleClick = async () => {
+    localStorage.setItem('code', code);
     if (MODE === 'development') {
       const token = await getDevCookie();
       document.cookie = `access_token=${token};`;
+      hide();
     }
-    localStorage.setItem('code', code);
+    reactQueryClient.invalidateQueries({ queryKey: [QUERY_KEYS.LOAD_CODES] });
   };
 
   return (


### PR DESCRIPTION
## PR 설명
기존의 code 목록을 불러오는 로직은 get 요청이 2번가는 비효율적인 구조였다.
이를 리액트 쿼리를 사용하여 code목록 캐싱 처리했다.


## ✅ 완료한 기능 명세
- [x] code목록 캐싱 처리
- [x] 버튼을 눌렀을 때 요청
- [x] 개발환경에서 쿠키 set시 쿼리 키에 대한 캐시 무효화

## 📸 스크린샷

### 기존상태
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/2f853dbf-3d67-49c3-bffd-3171348de722)
200 (실제 GET요청)이 2번 일어난다.

### 개선상태
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/abe0801f-27d1-4106-b8cb-39aaf2d05bd8)

첫 요청은 200, 이후에는 304로 캐시된 요청이 보인다.

## 고민과 해결과정

### 문제상황
기존에 useQuery의 enable 속성에 click State를 줬더니 클릭할때와, 데이터 패칭이 일어날때, 모두 렌더링이 일어나, 버튼을 누르는경우 2회의 렌더링이 일어나는 바람에 모달이 제대로 열리지 않는 문제가 있었다.

그래도 기능을 구현해야 했기에 버튼을 누르면 axios요청을 보내고, data를 받아오면 이걸 토대로 모달을 열어줬었다.
하지만 이때 모달 내부의 codes 데이터 상태를 유지하기 위해 여기서 useQuery를 사용했고, 결과적으로 2번의 GET요청이 가게 되었다.

굉장히 비효율적이었고, 이럴꺼면 react-query를 쓰지 않는 것이 더 효율적일 정도로 비효율적이었다.

### 개선
react-query는 query-key를 바탕으로 데이터를 캐싱한다.
따라서 다른 컴포넌트에서 같은 query-key에 대해 요청을 해도, 캐싱된 데이터가 있다면 같은 데이터를 반환하게 되는 것이다.

그렇다면, LoadButton에서 useQuery를 통해 모달을 열어주고, 모달 내부에서 useQuery를 사용해서 데이터를 유지시킬 수 있다.
그럼에도 불구하고 실제 데이터 요청은 단 1회만 가게 된다.

그럼 이제 LoadButton에서 조건에 따라 모달만 잘 열어주면된다.
enabled 옵션을 사용했는데, 이에따라 click상태가 바뀌면, click에 의해 1회, fetch에 의해 1회 총 2회의 렌더링이 일어나게된다.
이걸 useEffect에서 잘 분기처리 해주어야했다.

```typescript
export default function LoadButton({ ... }: LoadButtonProps) {
  const [click, setClick] = useState(false);
  const { show } = useModal(CodeListModal);
  const { data, isError, error } = useQuery({
    queryKey: [QUERY_KEYS.LOAD_CODES],
    queryFn: getUserCodes,
    enabled: click,
  });

  // useEffect에서 click에 대해서만 if를 따로 분기하면 모달이 열리지 않는다.
  useEffect(() => {
    if (data && click) { 
      show({ codeData: data, setPlainCode, setLanguage: setLanguageName, setFileName });
      setClick(false);
    }
    if (isError && click) { 
      errorCallback(error);
      setClick(false);
    }
  }, [click, data, isError]);
  ...
}
```