### PR TITLE
[FE] fix: 코드 실행 소켓 방식으로 변경

### DIFF
--- a/frontEnd/src/apis/postRunCode.ts
+++ b/frontEnd/src/apis/postRunCode.ts
@@ -1,7 +1,0 @@
-import Request from './Request';
-
-export default async function postRunCode(socketId: string, code: string, language: string) {
-  const response = await Request.post(`/run/v3?id=${socketId}`, { code, language });
-
-  return response.data;
-}

--- a/frontEnd/src/components/room/editor/EditorButton.tsx
+++ b/frontEnd/src/components/room/editor/EditorButton.tsx
@@ -1,15 +1,18 @@
 export default function EditorButton({
   children,
   onClick,
+  disabled,
 }: {
   children: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
-      className="flex items-center min-w-[8vh] justify-center px-[max(2vh,25px)] h-full text-sm drop-shadow-lg rounded whitespace-nowrap shadow bg-base text-black"
+      className="flex items-center justify-center w-24 h-full px-4 text-sm text-black rounded shadow drop-shadow-lg whitespace-nowrap bg-base"
       onClick={onClick}
+      disabled={disabled}
     >
       {children}
     </button>

--- a/frontEnd/src/components/room/editor/LoadButton.tsx
+++ b/frontEnd/src/components/room/editor/LoadButton.tsx
@@ -69,7 +69,7 @@ export default function LoadButton({ plainCode, setPlainCode, setLanguageName, s
 
   return (
     <div className="relative h-full">
-      <div className="peer flex items-center min-w-[8vh] justify-center px-[max(2vh,25px)] h-full text-sm  drop-shadow-lg rounded whitespace-nowrap shadow bg-base  text-black">
+      <div className="flex items-center justify-center w-24 h-full px-4 text-sm text-black rounded shadow cursor-pointer peer drop-shadow-lg whitespace-nowrap bg-base">
         불러오기
       </div>
       <div className="absolute z-10 items-center justify-between hidden gap-2 p-2 -translate-x-1/2 bg-white border rounded-lg drop-shadow-lg left-1/2 -top-12 peer-hover:flex hover:flex">

--- a/frontEnd/src/components/room/editor/SaveButton.tsx
+++ b/frontEnd/src/components/room/editor/SaveButton.tsx
@@ -43,7 +43,7 @@ export default function SaveButton({ plainCode, languageInfo, fileName, setFileN
 
   return (
     <div className="relative h-full">
-      <div className="peer flex items-center min-w-[8vh] justify-center px-[max(2vh,25px)] h-full text-sm  rounded whitespace-nowrap  drop-shadow-lg shadow bg-base text-black">
+      <div className="flex items-center justify-center w-24 h-full px-4 text-sm text-black rounded shadow cursor-pointer peer whitespace-nowrap drop-shadow-lg bg-base">
         저장하기
       </div>
       <div className="absolute z-10 items-center justify-between hidden gap-2 p-2 -translate-x-1/2 bg-white border rounded-lg shadow left-1/2 -top-12 peer-hover:flex hover:flex drop-shadow-lg">


### PR DESCRIPTION
## PR 설명
- 코드 실행 소켓 방식으로 변경

## ✅ 완료한 기능 명세
- [x] 코드 실행 소켓 방식으로 변경
- [x] 실행 중인 경우 스피너 출력 추가

## 📸 스크린샷
<img width="559" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/98c0c18a-8975-4058-b792-ab933de840ef">

## 고민과 해결과정
- 소켓 방식으로 변경되면서 이벤트가 순차적으로 일어나야 했음
  - 소켓 연결 -> 코드 실행 요청 이벤트 발생 -> (코드 실행) -> 결과 반환 이벤트 발생 -> 소켓 연결 종료
  - 이를 위해 각 이벤트가 순서대로 일어날 수 있도록 구성
  ```ts
  const handleExecCode = () => {
    executionSocket = io(VITE_CODE_RUNNING_SOCKET_URL, { transports: ['websocket'] });
  
    executionSocket.on('done', (response: RunCodeResponse) => {
      setExecResult(getOutputString(response));
      setIsExec(false);
  
      executionSocket.disconnect();
    });
  
    executionSocket.on('connect', () => {
      setIsExec(true);
      setExecResult('');
  
      executionSocket.emit('request', { code: plainCode, language: languageName });
    });
  };
  ```