### PR TITLE
[FE] refactor: DataChannel 전역 상태로 변경

### DIFF
--- a/frontEnd/src/components/room/editor/Editor.tsx
+++ b/frontEnd/src/components/room/editor/Editor.tsx
@@ -4,27 +4,21 @@ import InputArea from './InputArea';
 import LineNumber from './LineNumber';
 import { EDITOR_TAB_SIZE } from '@/constants/editor';
 import { LanguageInfo } from '@/types/editor';
-import { DataChannel } from '@/types/RTCConnection';
 import sendMessageDataChannels from '@/utils/sendMessageDataChannels';
 import { CRDTContext } from '@/contexts/crdt';
+import useDataChannels from '@/stores/useDataChannels';
 
 interface EditorProps {
   plainCode: string;
   languageInfo: LanguageInfo;
   setPlainCode: React.Dispatch<React.SetStateAction<string>>;
-  codeDataChannels: DataChannel[];
   cursorPosition: number;
   setCursorPosition: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function Editor({
-  plainCode,
-  languageInfo,
-  setPlainCode,
-  codeDataChannels,
-  cursorPosition,
-  setCursorPosition,
-}: EditorProps) {
+export default function Editor({ plainCode, languageInfo, setPlainCode, cursorPosition, setCursorPosition }: EditorProps) {
+  const { codeDataChannel } = useDataChannels();
+
   const crdt = useContext(CRDTContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -44,7 +38,7 @@ export default function Editor({
       crdt.getText('sharedText').delete(newCursor, removedLength);
     }
 
-    sendMessageDataChannels(codeDataChannels, Y.encodeStateAsUpdate(crdt));
+    sendMessageDataChannels(codeDataChannel, Y.encodeStateAsUpdate(crdt));
   };
 
   const handleClick = (event: React.MouseEvent<HTMLTextAreaElement>) => {
@@ -59,7 +53,7 @@ export default function Editor({
       event.preventDefault();
 
       crdt.getText('sharedText').insert(selectionStart, '    ');
-      sendMessageDataChannels(codeDataChannels, Y.encodeStateAsUpdate(crdt));
+      sendMessageDataChannels(codeDataChannel, Y.encodeStateAsUpdate(crdt));
 
       setCursorPosition((prev) => prev + EDITOR_TAB_SIZE);
       setPlainCode((prev) => `${prev.slice(0, selectionStart)}    ${prev.slice(selectionStart)}`);

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -18,11 +18,7 @@ export default function Room() {
   const [isSetting, setSetting] = useState((!!defaultCode || defaultCode === '') && !!defaultNickName);
   const [nickName, setNickName] = useState(defaultNickName || '');
 
-  const { streamList, codeDataChannels, languageDataChannels } = useRTCConnection(
-    roomId as string,
-    mediaObject.stream as MediaStream,
-    isSetting,
-  );
+  const { streamList } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream, isSetting);
 
   if (!isSetting) return <Setting mediaObject={mediaObject} setSetting={setSetting} setNickName={setNickName} />;
 
@@ -38,7 +34,7 @@ export default function Room() {
             <ControllSection mediaObject={mediaObject} />
           </div>
           <div className="w-3/5 max-h-full">
-            <EditorSection defaultCode={defaultCode} codeDataChannels={codeDataChannels} languageDataChannels={languageDataChannels} />
+            <EditorSection defaultCode={defaultCode} />
           </div>
         </div>
       </div>

--- a/frontEnd/src/stores/useDataChannels.ts
+++ b/frontEnd/src/stores/useDataChannels.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { DataChannel } from '@/types/RTCConnection';
+
+interface DataChannels {
+  codeDataChannel: DataChannel[];
+  addCodeDataChannel: (socketId: string, dataChannel: RTCDataChannel) => void;
+  removeCodeDataChannel: (value: { id: string }) => void;
+
+  languageDataChannel: DataChannel[];
+  addLanguageChannel: (socketId: string, dataChannel: RTCDataChannel) => void;
+  removeLanguageChannel: (value: { id: string }) => void;
+}
+
+const useDataChannels = create<DataChannels>((set) => ({
+  codeDataChannel: [],
+  addCodeDataChannel: (id, dataChannel) => set((state) => ({ ...state, codeDataChannel: [...state.codeDataChannel, { id, dataChannel }] })),
+  removeCodeDataChannel: (data) =>
+    set((state) => ({ ...state, codeDataChannel: [...state.codeDataChannel.filter(({ id }) => id !== data.id)] })),
+
+  languageDataChannel: [],
+  addLanguageChannel: (id, dataChannel) =>
+    set((state) => ({ ...state, languageDataChannel: [...state.languageDataChannel, { id, dataChannel }] })),
+  removeLanguageChannel: (data) =>
+    set((state) => ({ ...state, languageDataChannel: [...state.languageDataChannel.filter(({ id }) => id !== data.id)] })),
+}));
+
+export default useDataChannels;


### PR DESCRIPTION
## PR 설명
- DataChannel 전역 상태로 변경

## ✅ 완료한 기능 명세
- [x] codeDataChannel 전역 상태로 변경
- [x] languageDataChannel 전역 상태로 변경

## 📸 스크린샷
```ts
import { create } from 'zustand';
import { DataChannel } from '@/types/RTCConnection';

interface DataChannels {
  codeDataChannel: DataChannel[];
  addCodeDataChannel: (socketId: string, dataChannel: RTCDataChannel) => void;
  removeCodeDataChannel: (value: { id: string }) => void;

  languageDataChannel: DataChannel[];
  addLanguageChannel: (socketId: string, dataChannel: RTCDataChannel) => void;
  removeLanguageChannel: (value: { id: string }) => void;
}

const useDataChannels = create<DataChannels>((set) => ({
  codeDataChannel: [],
  addCodeDataChannel: (id, dataChannel) => set((state) => ({ ...state, codeDataChannel: [...state.codeDataChannel, { id, dataChannel }] })),
  removeCodeDataChannel: (data) =>
    set((state) => ({ ...state, codeDataChannel: [...state.codeDataChannel.filter(({ id }) => id !== data.id)] })),

  languageDataChannel: [],
  addLanguageChannel: (id, dataChannel) =>
    set((state) => ({ ...state, languageDataChannel: [...state.languageDataChannel, { id, dataChannel }] })),
  removeLanguageChannel: (data) =>
    set((state) => ({ ...state, languageDataChannel: [...state.languageDataChannel.filter(({ id }) => id !== data.id)] })),
}));

export default useDataChannels;
```

## 고민과 해결과정
- 전역 상태로 변경한 이유
  - 매우 깊은 depth 까지 props drilling이 발생했으며 그 과정에서 중간 단계에 있는 컴포넌트에 불필요한 재렌더링이 되는 것을 해결하기 위해