### PR TITLE
[FE] refactor: roomConfigData 전역 state로 관리

### DIFF
--- a/frontEnd/src/components/room/ChattingSection.tsx
+++ b/frontEnd/src/components/room/ChattingSection.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import { Socket, io } from 'socket.io-client/debug';
 import { VITE_CHAT_URL } from '@/constants/env';
@@ -10,21 +11,20 @@ import { CHATTING_SOCKET_EMIT_EVNET, CHATTING_SOCKET_RECIEVE_EVNET } from '@/con
 import Section from '../common/SectionWrapper';
 import { CHATTING_ERROR_STATUS_CODE, CHATTING_ERROR_TEXT } from '@/constants/chattingErrorResponse';
 import ChattingErrorToast from '../common/ChattingErrorToast';
-
-interface ChattingSectionProps {
-  roomId: string;
-  nickname: string;
-}
+import useRoomConfigData from '@/stores/useRoomConfigData';
 
 let socket: Socket;
 let timer: NodeJS.Timeout | null;
 
-export default function ChattingSection({ roomId, nickname }: ChattingSectionProps) {
+export default function ChattingSection() {
   const [message, setMessage] = useState('');
   const [allMessages, setAllMessage] = useState<MessageData[]>([]);
   const [usingAi, setUsingAi] = useState<boolean>(false);
   const [postingAi, setPostingAi] = useState<boolean>(false);
   const [errorData, setErrorData] = useState<ErrorData | null>(null);
+  const { roomId } = useParams();
+
+  const nickname = useRoomConfigData((state) => state.nickname);
 
   const { isViewingLastMessage, isRecievedMessage, setScrollRatio, setIsRecievedMessage } = useLastMessageViewingState();
 

--- a/frontEnd/src/components/setting/MediaSelector.tsx
+++ b/frontEnd/src/components/setting/MediaSelector.tsx
@@ -12,7 +12,7 @@ export default function MediaSelector({
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setFunc(e.target.value);
   };
-  if (Object.keys(stream).length === 0) return <div />;
+  if (!stream.id) return <div />;
 
   const [videoTrack] = stream.getVideoTracks();
   const [audioTrack] = stream.getAudioTracks();

--- a/frontEnd/src/components/setting/Settings.tsx
+++ b/frontEnd/src/components/setting/Settings.tsx
@@ -5,22 +5,16 @@ import SettingVideo from './SettingVideo';
 import Header from '../common/Header';
 import useFocus from '@/hooks/useFocus';
 import useInput from '@/hooks/useInput';
+import useRoomConfigData from '@/stores/useRoomConfigData';
 
-export default function Setting({
-  mediaObject,
-  setSetting,
-  setNickName,
-}: {
-  mediaObject: MediaObject;
-  setSetting: React.Dispatch<React.SetStateAction<boolean>>;
-  setNickName: React.Dispatch<React.SetStateAction<string>>;
-}) {
+export default function Setting({ mediaObject }: { mediaObject: MediaObject }) {
+  const { setNickname, settingOn } = useRoomConfigData((state) => state.actions);
   const ref = useFocus<HTMLInputElement>();
   const { inputValue, onChange } = useInput(randomNameGenerator());
   const onClick = () => {
-    setNickName(inputValue);
+    setNickname(inputValue);
     localStorage.setItem('nickName', inputValue);
-    setSetting(true);
+    settingOn();
   };
   return (
     <div>

--- a/frontEnd/src/components/setting/Settings.tsx
+++ b/frontEnd/src/components/setting/Settings.tsx
@@ -11,11 +11,13 @@ export default function Setting({ mediaObject }: { mediaObject: MediaObject }) {
   const { setNickname, settingOn } = useRoomConfigData((state) => state.actions);
   const ref = useFocus<HTMLInputElement>();
   const { inputValue, onChange } = useInput(randomNameGenerator());
+
   const onClick = () => {
     setNickname(inputValue);
     localStorage.setItem('nickName', inputValue);
     settingOn();
   };
+
   return (
     <div>
       <div className="mb-[5%]  mx-[7vw] mt-4">

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import useRTCConnection from '@/hooks/useRTCConnection';
 import Setting from '@/components/setting/Settings';
@@ -8,19 +7,18 @@ import QuizViewSection from '@/components/room/QuizViewSection';
 import EditorSection from '@/components/room/EditorSection';
 import ChattingSection from '@/components/room/ChattingSection';
 import ControllSection from '@/components/room/ControllSection';
+import useRoomConfigData from '@/stores/useRoomConfigData';
 
 export default function Room() {
   const defaultCode = localStorage.getItem('code');
-  const defaultNickName = localStorage.getItem('nickName');
   const { roomId } = useParams();
   const mediaObject = useMedia();
 
-  const [isSetting, setSetting] = useState((!!defaultCode || defaultCode === '') && !!defaultNickName);
-  const [nickName, setNickName] = useState(defaultNickName || '');
+  const isSetting = useRoomConfigData((state) => state.isSetting);
 
   const { streamList } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream, isSetting);
 
-  if (!isSetting) return <Setting mediaObject={mediaObject} setSetting={setSetting} setNickName={setNickName} />;
+  if (!isSetting) return <Setting mediaObject={mediaObject} />;
 
   return (
     <div className="flex w-screen h-screen gap-4 p-2 bg-base">
@@ -39,7 +37,7 @@ export default function Room() {
         </div>
       </div>
       <div className="flex w-1/4 ">
-        <ChattingSection roomId={roomId as string} nickname={nickName} />
+        <ChattingSection />
       </div>
     </div>
   );

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -14,7 +14,7 @@ export default function Room() {
   const { roomId } = useParams();
   const mediaObject = useMedia();
 
-  const isSetting = useRoomConfigData((state) => state.isSetting);
+  const isSetting = useRoomConfigData((state) => state.isSettingDone);
 
   const { streamList } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream, isSetting);
 

--- a/frontEnd/src/stores/useRoomConfigData.ts
+++ b/frontEnd/src/stores/useRoomConfigData.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+interface RoomConfigData {
+  isSetting: boolean;
+  nickname: string;
+  actions: {
+    settingOn: () => void;
+    settingOff: () => void;
+    setNickname: (value: string) => void;
+  };
+}
+
+const defaultCode = localStorage.getItem('code');
+const defaultNickName = localStorage.getItem('nickName');
+
+const useRoomConfigData = create<RoomConfigData>((set) => ({
+  isSetting: (!!defaultCode || defaultCode === '') && !!defaultNickName,
+  nickname: defaultNickName || '',
+  actions: {
+    settingOn: () => set((state) => ({ ...state, isSetting: true })),
+    settingOff: () => set((state) => ({ ...state, isSetting: false })),
+    setNickname: (value) => set((state) => ({ ...state, nickname: value })),
+  },
+}));
+
+export default useRoomConfigData;

--- a/frontEnd/src/stores/useRoomConfigData.ts
+++ b/frontEnd/src/stores/useRoomConfigData.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 
 interface RoomConfigData {
-  isSetting: boolean;
+  isSettingDone: boolean;
   nickname: string;
   actions: {
     settingOn: () => void;
@@ -14,11 +14,11 @@ const defaultCode = localStorage.getItem('code');
 const defaultNickName = localStorage.getItem('nickName');
 
 const useRoomConfigData = create<RoomConfigData>((set) => ({
-  isSetting: (!!defaultCode || defaultCode === '') && !!defaultNickName,
+  isSettingDone: (!!defaultCode || defaultCode === '') && !!defaultNickName,
   nickname: defaultNickName || '',
   actions: {
-    settingOn: () => set((state) => ({ ...state, isSetting: true })),
-    settingOff: () => set((state) => ({ ...state, isSetting: false })),
+    settingOn: () => set((state) => ({ ...state, isSettingDone: true })),
+    settingOff: () => set((state) => ({ ...state, isSettingDone: false })),
     setNickname: (value) => set((state) => ({ ...state, nickname: value })),
   },
 }));


### PR DESCRIPTION
## PR 설명
 roomConfigData 전역 state로 관리

## ✅ 완료한 기능 명세
- [x] useRoomConfigData 추가
- [x] 기존 컴포넌트에 적용
- [x] MediaSelector가 안보이는 오류해결

## 스크린샷
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/5887c4a4-85bc-43c2-99d5-09d5c77b5ea1)


## 고민과 해결과정

Room에서 nickname과 setting을 props로 계속해서 넘겨주어 가독성이 나빠지는 부분을 개선하였습니다!
nickname과 setting관련 상태와 함수를 useRoomConfigData로 관리하였습니다.
