### PR TITLE
[FE] fix: Home으로 돌아가는 경우 setting을 Off로 변경

### DIFF
--- a/frontEnd/src/pages/Home.tsx
+++ b/frontEnd/src/pages/Home.tsx
@@ -1,11 +1,18 @@
+import { useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/common/Button';
 import useInput from '@/hooks/useInput';
+import useRoomConfigData from '@/stores/useRoomConfigData';
 
 export default function Home() {
   const navigate = useNavigate();
   const { inputValue, onChange } = useInput('');
+  const { settingOff } = useRoomConfigData((state) => state.actions);
+
+  useEffect(() => {
+    settingOff();
+  }, []);
 
   const handleMakeRoomClick = () => {
     const roomId = uuidv4();


### PR DESCRIPTION
## PR 설명
 Home으로 돌아가는 경우 setting을 Off로 변경

## ✅ 완료한 기능 명세
- [x]  Home으로 돌아가는 경우 setting을 Off로 변경


## 고민과 해결과정
기존에 room에 들어갔다가 다시 home으로 돌아오는경우 state가 유지되기때문에 isSettingOn이 true라서 방설정 창을 거치지 않고 넘어가는 문제가 있었다.
home이 마운트될 때 settingDone값을 명시적으로 off로 바꿔서 해결했다.