### PR TITLE
[FE] feat: 언어추가 swift, kotlin

### DIFF
--- a/frontEnd/src/configs/highlightCodeConfig.ts
+++ b/frontEnd/src/configs/highlightCodeConfig.ts
@@ -4,10 +4,14 @@ import python from 'highlight.js/lib/languages/python';
 import javascript from 'highlight.js/lib/languages/javascript';
 import java from 'highlight.js/lib/languages/java';
 import c from 'highlight.js/lib/languages/c';
+import swift from 'highlight.js/lib/languages/swift';
+import kotlin from 'highlight.js/lib/languages/kotlin';
 
 codeHighlighter.registerLanguage('python', python);
 codeHighlighter.registerLanguage('javascript', javascript);
 codeHighlighter.registerLanguage('java', java);
 codeHighlighter.registerLanguage('c', c);
+codeHighlighter.registerLanguage('swift', swift);
+codeHighlighter.registerLanguage('kotlin', kotlin);
 
 export default codeHighlighter;

--- a/frontEnd/src/constants/editor.ts
+++ b/frontEnd/src/constants/editor.ts
@@ -22,6 +22,16 @@ export const EDITOR_LANGUAGE_TYPES: Record<string, LanguageInfo> = {
     optionText: 'C',
     extension: 'c',
   },
+  kotlin: {
+    name: 'kotlin',
+    optionText: 'Kotlin',
+    extension: 'kt',
+  },
+  swift: {
+    name: 'swift',
+    optionText: 'Swift',
+    extension: 'swift',
+  },
 };
 
 export const EDITOR_DEFAULT_LANGUAGE = 'python';

--- a/frontEnd/src/types/editor.ts
+++ b/frontEnd/src/types/editor.ts
@@ -1,4 +1,4 @@
-export type Language = 'python' | 'javascript' | 'java' | 'c';
+export type Language = 'python' | 'javascript' | 'java' | 'c' | 'swift' | 'kotlin' | 'swift';
 
 export interface LanguageInfo {
   name: Language;


### PR DESCRIPTION


## PR 설명
언어추가 swift, kotlin

## ✅ 완료한 기능 명세
- [x] 언어추가 swift, kotlin

## 📸 스크린샷
![image](https://github.com/boostcampwm2023/web05-AlgoITNi/assets/99241871/578a4d12-1774-426f-9a6a-dc882cb16dbc)

## 고민과 해결과정
기존의 작성된 타입에 추가하는 형태로 구현했다.
