### PR TITLE
[FE] fix: 로그인 리다이렉트시 방설정 창이 보이는 오류 해결

### DIFF
--- a/frontEnd/src/components/room/modal/LoginModal.tsx
+++ b/frontEnd/src/components/room/modal/LoginModal.tsx
@@ -37,6 +37,7 @@ export default function LoginModal({ code }: { code: string }) {
       const token = await getDevCookie();
       document.cookie = `access_token=${token};`;
       hide();
+      window.location.reload();
     }
     reactQueryClient.invalidateQueries({ queryKey: [QUERY_KEYS.LOAD_CODES] });
   };

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import useRTCConnection from '@/hooks/useRTCConnection';
 import Setting from '@/components/setting/Settings';
@@ -10,10 +9,11 @@ import ChattingSection from '@/components/room/ChattingSection';
 import ControllSection from '@/components/room/ControllSection';
 import useRoomConfigData from '@/stores/useRoomConfigData';
 
+const defaultCode = localStorage.getItem('code');
+const defaultNickName = localStorage.getItem('nickName');
+const hasLogin = (!!defaultCode || defaultCode === '') && !!defaultNickName;
+
 export default function Room() {
-  const defaultCode = localStorage.getItem('code');
-  const defaultNickName = localStorage.getItem('nickName');
-  const [hasLogin] = useState((!!defaultCode || defaultCode === '') && !!defaultNickName);
   const { roomId } = useParams();
   const mediaObject = useMedia();
   const isConnectionDone = useRoomConfigData((state) => state.isConnectionDone);

--- a/frontEnd/src/pages/Room.tsx
+++ b/frontEnd/src/pages/Room.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import useRTCConnection from '@/hooks/useRTCConnection';
 import Setting from '@/components/setting/Settings';
@@ -11,15 +12,14 @@ import useRoomConfigData from '@/stores/useRoomConfigData';
 
 export default function Room() {
   const defaultCode = localStorage.getItem('code');
-
+  const defaultNickName = localStorage.getItem('nickName');
+  const [hasLogin] = useState((!!defaultCode || defaultCode === '') && !!defaultNickName);
   const { roomId } = useParams();
   const mediaObject = useMedia();
-
   const isConnectionDone = useRoomConfigData((state) => state.isConnectionDone);
 
   const { streamList } = useRTCConnection(roomId as string, mediaObject.stream as MediaStream);
-
-  if (!isConnectionDone) return <Setting mediaObject={mediaObject} />;
+  if (!isConnectionDone && !hasLogin) return <Setting mediaObject={mediaObject} />;
 
   return (
     <div className="flex w-screen h-screen gap-4 p-2 bg-base">


### PR DESCRIPTION
로그인 리다이렉트시 방설정 창이 보이는 오류 해결


## PR 설명
- 로그인 리다이렉트시 방설정 창이 보이는 오류 해결

## ✅ 완료한 기능 명세
- [x] 로그인 리다이렉트시 방설정 창이 보이는 오류 해결

## 고민과 해결과정
기존의 isSettingDone이 그 역할을 했으나, 현재 isSettingDone는 signal을 시작시키는 트리거형태로 작동하기 때문에, 로그인시의 redirection인지, 첫 접속인지 분기할 필요가 있었다.

hasLogin이라는 변수를 하나 선언하고이전에 저장된 code와 nickName값에 따라 로그인 리다이렉션인지, 처음 접속하는 과정인지를 분기할 수 있도록 했다.

```typescript

const defaultCode = localStorage.getItem('code');
const defaultNickName = localStorage.getItem('nickName');
const hasLogin = (!!defaultCode || defaultCode === '') && !!defaultNickName;

export default function Room() {
  if (!isConnectionDone && !hasLogin) return <Setting mediaObject={mediaObject} />;
...
}
```
