### PR TITLE
[FE] refactor: 채팅 영역 리팩토링

### DIFF
--- a/frontEnd/src/components/common/ChattingErrorToast.tsx
+++ b/frontEnd/src/components/common/ChattingErrorToast.tsx
@@ -7,7 +7,7 @@ interface ChattingErrorToastProps {
 
 export default function ChattingErrorToast({ errorData, setErrorData }: ChattingErrorToastProps) {
   return (
-    <div className="absolute z-10 flex flex-col items-start w-full bottom-24 ">
+    <div className="absolute z-10 flex flex-col items-start w-full bottom-28 ">
       <div className="flex flex-col p-5 mb-5 ml-5 drop-shadow-lg bg-base">
         <span className="text-sm">{errorData.text1}</span>
         <span className="text-sm">{errorData.text2}</span>

--- a/frontEnd/src/components/room/ChattingSection.tsx
+++ b/frontEnd/src/components/room/ChattingSection.tsx
@@ -37,6 +37,8 @@ export default function ChattingSection() {
 
     if (usingAi) {
       setPostingAi(true);
+
+      socket.emit(CHATTING_SOCKET_EMIT_EVNET.SEND_MESSAGE, { room: roomId, message, nickname: `${nickname}의 질문`, ai: false });
       socket.emit(CHATTING_SOCKET_EMIT_EVNET.SEND_MESSAGE, { room: roomId, message, nickname, ai: true });
     } else socket.emit(CHATTING_SOCKET_EMIT_EVNET.SEND_MESSAGE, { room: roomId, message, nickname, ai: false });
 

--- a/frontEnd/src/components/room/ChattingSection.tsx
+++ b/frontEnd/src/components/room/ChattingSection.tsx
@@ -18,7 +18,7 @@ import useScroll from '@/hooks/useScroll';
 let socket: Socket;
 
 export default function ChattingSection() {
-  const { inputValue: message, onChange, resetInput } = useInput('');
+  const { inputValue: message, onChange, resetInput } = useInput<HTMLTextAreaElement>('');
   const [allMessages, setAllMessage] = useState<MessageData[]>([]);
   const [usingAi, setUsingAi] = useState<boolean>(false);
   const [postingAi, setPostingAi] = useState<boolean>(false);

--- a/frontEnd/src/components/room/ChattingSection.tsx
+++ b/frontEnd/src/components/room/ChattingSection.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Socket, io } from 'socket.io-client/debug';
 import { VITE_CHAT_URL } from '@/constants/env';
 import { ErrorData, ErrorResponse, MessageData } from '@/types/chatting';
@@ -13,7 +13,7 @@ import { CHATTING_ERROR_STATUS_CODE, CHATTING_ERROR_TEXT } from '@/constants/cha
 import ChattingErrorToast from '../common/ChattingErrorToast';
 import useScroll from '@/hooks/useScroll';
 
-export default function ChattingSection() {
+function ChattingSection() {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [allMessages, setAllMessage] = useState<MessageData[]>([]);
 
@@ -99,3 +99,5 @@ export default function ChattingSection() {
     </Section>
   );
 }
+
+export default memo(ChattingSection);

--- a/frontEnd/src/components/room/chatting/ChattingInput.tsx
+++ b/frontEnd/src/components/room/chatting/ChattingInput.tsx
@@ -11,7 +11,7 @@ function SendButtonText({ usingAi, postingAi }: { usingAi: boolean; postingAi: b
 interface ChattingInputProps {
   handleMessageSend: (event: React.FormEvent<HTMLFormElement>) => void;
   message: string;
-  handleInputMessage: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleInputMessage: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   usingAi: boolean;
   setUsingAi: React.Dispatch<React.SetStateAction<boolean>>;
   postingAi: boolean;
@@ -25,21 +25,30 @@ export default function ChattingInput({
   setUsingAi,
   postingAi,
 }: ChattingInputProps) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleMessageSend(event as unknown as React.FormEvent<HTMLFormElement>);
+    }
+  };
+
   return (
     <form onSubmit={handleMessageSend} className="w-full p-2 rounded-b-lg bg-base">
       <ToggleAi usingAi={usingAi} setUsingAi={setUsingAi} />
-      <div className="flex items-center w-full h-12 rounded-lg drop-shadow-lg">
-        <input
+      <div className="flex items-center w-full h-[72px] rounded-lg drop-shadow-lg">
+        <textarea
+          onKeyDown={handleKeyDown}
           disabled={usingAi && postingAi}
-          type="text"
           value={message}
           onChange={handleInputMessage}
-          className={`w-full h-12 p-2 px-4 focus:outline-none rounded-s-lg ${usingAi ? 'border-point-blue border-2' : ''}`}
+          className={`w-full h-full p-2 px-4 focus:outline-none rounded-s-lg resize-none border-2 custom-scroll ${
+            usingAi ? 'border-point-blue' : 'border-white'
+          }`}
           placeholder={usingAi ? 'AI에게 질문해보세요' : 'Message'}
         />
         <button
           type="submit"
-          className={`h-full px-4 py-1 font-normal rounded-e-lg whitespace-nowrap w-16 flex items-center justify-center ${
+          className={`font-normal rounded-e-lg whitespace-nowrap w-16 flex items-center justify-center h-full ${
             usingAi ? 'bg-point-blue text-white' : 'bg-primary text-black'
           }`}
           disabled={usingAi && postingAi}

--- a/frontEnd/src/components/room/chatting/ChattingInput.tsx
+++ b/frontEnd/src/components/room/chatting/ChattingInput.tsx
@@ -3,8 +3,8 @@ import ToggleAi from '@/components/common/ToggleAi';
 
 function SendButtonText({ usingAi, postingAi }: { usingAi: boolean; postingAi: boolean }) {
   if (!usingAi) return '전송';
-
   if (postingAi) return <Spinner />;
+
   return '질문';
 }
 

--- a/frontEnd/src/components/room/chatting/ChattingMessage.tsx
+++ b/frontEnd/src/components/room/chatting/ChattingMessage.tsx
@@ -20,7 +20,7 @@ export default function ChattingMessage({ messageData, isMyMessage }: ChattingMe
     <div className={`flex flex-col gap-0.5 ${myMessage ? 'items-end' : 'items-start'}`}>
       <span className="mx-1 text-xs font-light">{aiMessage ? '클로바 X' : messageData.nickname}</span>
       <div className={`px-4 py-2 rounded-lg w-fit ${getMessageColor()}`}>
-        <span>{messageData.message}</span>
+        <span className="whitespace-pre-wrap">{messageData.message}</span>
       </div>
     </div>
   );

--- a/frontEnd/src/components/room/chatting/ChattingMessage.tsx
+++ b/frontEnd/src/components/room/chatting/ChattingMessage.tsx
@@ -6,10 +6,20 @@ interface ChattingMessageProps {
 }
 
 export default function ChattingMessage({ messageData, isMyMessage }: ChattingMessageProps) {
+  const aiMessage = messageData.ai;
+  const myMessage = !aiMessage && isMyMessage;
+
+  const getMessageColor = () => {
+    if (aiMessage) return 'bg-point-blue text-white';
+    if (myMessage) return 'bg-blue-100';
+
+    return 'bg-yellow-100';
+  };
+
   return (
-    <div className={`flex flex-col gap-0.5 ${isMyMessage ? 'items-end' : 'items-start'}`}>
-      <span className="mx-1 text-xs font-light ">{messageData.nickname}</span>
-      <div className={`px-4 py-2 rounded-lg w-fit ${isMyMessage ? 'bg-blue-100' : 'bg-yellow-100'}`}>
+    <div className={`flex flex-col gap-0.5 ${myMessage ? 'items-end' : 'items-start'}`}>
+      <span className="mx-1 text-xs font-light">{aiMessage ? '클로바 X' : messageData.nickname}</span>
+      <div className={`px-4 py-2 rounded-lg w-fit ${getMessageColor()}`}>
         <span>{messageData.message}</span>
       </div>
     </div>

--- a/frontEnd/src/components/room/chatting/ChattingMessage.tsx
+++ b/frontEnd/src/components/room/chatting/ChattingMessage.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { MessageData } from '@/types/chatting';
 
 interface ChattingMessageProps {
@@ -5,7 +6,7 @@ interface ChattingMessageProps {
   isMyMessage: boolean;
 }
 
-export default function ChattingMessage({ messageData, isMyMessage }: ChattingMessageProps) {
+function ChattingMessage({ messageData, isMyMessage }: ChattingMessageProps) {
   const aiMessage = messageData.ai;
   const myMessage = !aiMessage && isMyMessage;
 
@@ -25,3 +26,5 @@ export default function ChattingMessage({ messageData, isMyMessage }: ChattingMe
     </div>
   );
 }
+
+export default memo(ChattingMessage);

--- a/frontEnd/src/hooks/useInput.ts
+++ b/frontEnd/src/hooks/useInput.ts
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
-export default function useInput(initialValue: string) {
+export default function useInput<T extends HTMLInputElement | HTMLTextAreaElement>(initialValue: string) {
   const [inputValue, setInputValue] = useState(initialValue);
 
-  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = (event: React.ChangeEvent<T>) => {
     const {
       target: { value },
     } = event;


### PR DESCRIPTION
## PR 설명
- 채팅 영역 리팩토링
- close #217 

## ✅ 완료한 기능 명세
- [x] 멀티 라인 지원
- [x] 렌더링 최적화
- [x] AI가 보낸 메시지 색상 구분

## 📸 스크린샷
<img width="988" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/ff33ea5b-3ffb-45f1-b6f5-af6cd761966b">
<img width="325" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/dc48b7e1-4c58-4332-9249-ec5955af2aca">
<img width="325" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/05f9ab8d-b65e-4967-a85a-aff2477cf2f6">
<img width="324" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/c57ddf84-9c9b-482c-a0da-83efd83ec177">
<img width="324" alt="image" src="https://github.com/boostcampwm2023/web05-AlgoITNi/assets/96584994/d02b2816-c18c-4035-99b6-23fc0588b220">

## 고민과 해결과정
- 입력에 의해 메시지 영역의 모든 메시지가 재렌더링 되는 문제 발생
  - 기존에는 state를 최상위 컴포넌트인 ChattingSection이 가지고 있었기 때문에 발생한 문제
  - 이를 해결하기 위해 가능한 많은 state를 최하위 컴포넌트가 갖고 있을 수 있도록 수정
  - state의 변경 영향을 최소화 시키기 위함
- React memo 기능을 이용하여 한 번 렌더링 된 메시지가 재렌더링 되는 것을 방지