### PR TITLE
[BE] fix: 컴파일이 필요한 언어 코드 실행 fix

### DIFF
--- a/backEnd/running/src/common/supportLang.ts
+++ b/backEnd/running/src/common/supportLang.ts
@@ -19,21 +19,24 @@ export const distExtName = {
   kotlin: '.jar',
 };
 
-export function languageCommand(language, filePaths) {
+export function languageCommand(language, filePaths): string[] {
   const [filepath, compile_dist] = filePaths;
   switch (language) {
     case 'python':
-      return `python3 ${filepath}`;
+      return [`python3 ${filepath}`];
     case 'javascript':
-      return `node ${filepath}`;
+      return [`node ${filepath}`];
     case 'java':
-      return `java ${filepath}`;
+      return [`java ${filepath}`];
     case 'c':
-      return `gcc -o ${compile_dist} ${filepath} && ${compile_dist}`;
+      return [`gcc -o ${compile_dist} ${filepath}`, compile_dist];
     case 'swift':
-      return `swiftc -o ${compile_dist} ${filepath} && ${compile_dist}`;
+      return [`swiftc -o ${compile_dist} ${filepath}`, compile_dist];
     case 'kotlin':
-      return `kotlinc ${filepath} -include-runtime -d ${compile_dist} && java -jar ${compile_dist}`;
+      return [
+        `kotlinc ${filepath} -include-runtime -d ${compile_dist}`,
+        `java -jar ${compile_dist}`,
+      ];
   }
 }
 export const needCompile = ['c', 'swift', 'kotlin'];


### PR DESCRIPTION
## PR 설명
- 컴파일이 필요한 언어 코드 실행 fix

## ✅ 완료한 기능 명세
- [x] 컴파일 과정 추가 

## 고민과 해결과정
c, swift, kotlin의 경우  cli로 언어를 실행시킬때 두 번의 명령어 입력이 필요함.
exec에서 spawn으로 변경하면서 자식프로세스 생성시 커맨드 전달방식 변경되었음

[기존]
`gcc -o target target.c && target`으로 명령어 실행

[변경]
`gcc -o target target.c`
`target`
두 단계로 나누고, 자식프로세스를 두 번 생성